### PR TITLE
Added limited launch file parser (fixes #216)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ docs = build_sphinx
 addopts = -rx -v
 
 [pycodestyle]
-ignore = W605
+ignore = W605,E704
 max_line_length = 79
 
 [mypy]

--- a/src/roswire/name.py
+++ b/src/roswire/name.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 __all__ = (
+    'canonical_name',
     'global_name',
     'namespace',
     'namespace_join',
@@ -8,7 +9,7 @@ __all__ = (
 
 
 def global_name(name: str) -> str:
-    """Converts a name to its canonical global form."""
+    """Converts a name to its global form."""
     if name_is_private(name):
         m = f'cannot convert private name [{name}] into global name'
         raise ValueError(m)
@@ -17,6 +18,15 @@ def global_name(name: str) -> str:
     if name[-1] != '/':
         name = name + '/'
     return name
+
+
+def canonical_name(name: str) -> str:
+    """Returns the canonical form of a given name."""
+    if not name:
+        return ''
+    if name[0] == '/':
+        return '/' + '/'.join(n for n in name[1:].split('/') if n)
+    return '/'.join(n for n in name.split('/') if n)
 
 
 def name_is_private(name: str) -> bool:

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -13,6 +13,7 @@ import xml.etree.ElementTree as ET
 import attr
 
 from .config import ROSConfig, NodeConfig
+from .context import LaunchContext
 from ..substitution import resolve as resolve_args
 from ..shell import ShellProxy
 from ..file import FileProxy
@@ -37,121 +38,6 @@ def _parse_bool(attr: str, val: Optional[str], default: bool) -> bool:
 
     m = f'illegal boolean attribute [{attr}]: {val}'
     raise FailedToParseLaunchFile(m)
-
-
-@attr.s(frozen=True, slots=True)
-class LaunchContext:
-    filename: str = attr.ib()
-    resolve_dict: Mapping[str, Any] = attr.ib()
-    include_resolve_dict: Mapping[str, Any] = attr.ib()
-    parent: 'LaunchContext' = attr.ib(default=None)
-    namespace: str = attr.ib(default='/')
-    arg_names: Tuple[str, ...] = attr.ib(default=tuple())
-    env_args: Tuple[Tuple[str, str], ...] = attr.ib(default=tuple())
-    pass_all_args: bool = attr.ib(default=False)
-
-    def include_child(self,
-                      ns: Optional[str],
-                      filename: str
-                      ) -> 'LaunchContext':
-        ctx = self.child(ns)
-        ctx = attr.evolve(ctx,
-                          filename=filename,
-                          arg_names=tuple(),
-                          include_resolve_dict={})
-        return ctx
-
-    def child(self, ns: Optional[str] = None) -> 'LaunchContext':
-        """Creates a child context that inherits from this context."""
-        if ns is None:
-            child_ns = self.namespace
-        elif ns.startswith('/') or ns == '~':
-            child_ns = ns
-        else:
-            child_ns = namespace_join(self.namespace, ns)
-        return attr.evolve(self,
-                           namespace=child_ns,
-                           parent=self,
-                           pass_all_args=False)
-
-    def with_pass_all_args(self) -> 'LaunchContext':
-        ctx = self
-        if 'arg' in self.parent.resolve_dict:
-            for var, val in self.parent.resolve_dict['arg'].items():
-                ctx = ctx.with_arg(var, value=val)
-        return attrs.evolve(ctx, pass_all_args=True)
-
-    def process_include_args(self) -> 'LaunchContext':
-        if self.include_resolve_dict is None:
-            return attr.evolve(self, arg_names=tuple())
-
-        arg_dict = self.include_resolve_dict.get('arg', {})
-        for arg in self.arg_names:
-            if not arg in arg_dict:
-                m = f'include arg [{arg}] is missing value.'
-                raise FailedToParseLaunchFile(m)
-
-        return attr.evolve(self,
-                           arg_names=tuple(),
-                           resolve_dict=deepcopy(self.include_resolve_dict),
-                           include_resolve_dict=None)
-
-    def with_argv(self, argv: Sequence[str]) -> 'LaunchContext':
-        # ignore parameter assignment mappings
-        logger.debug("loading argv: %s", argv)
-        mappings: Dict[str, str] = {}
-        for arg in (a for a in argv if ':=' in a):
-            var, sep, val = [a.strip() for a in arg.partition(':=')]
-            if not var.startswith('__'):
-                mappings[var] = val
-        logger.debug("loaded argv: %s", mappings)
-        resolve_dict = self.resolve_dict.copy()
-        resolve_dict['arg'] = mappings
-        return attr.evolve(self, resolve_dict=resolve_dict)
-
-    def with_env_arg(self, var: str, val: Any) -> 'LaunchContext':
-        env_args = self.env_args + ((var, val),)
-        return attr.evolve(self, env_args=env_args)
-
-    def with_arg(self,
-                 name: str,
-                 default: Optional[Any] = None,
-                 value: Optional[Any] = None,
-                 doc: Optional = None
-                 ) -> 'LaunchContext':
-        logger.debug("adding arg [%s] to context", name)
-        arg_names = self.arg_names
-        if name in self.arg_names:
-            if not self.pass_all_args:
-                m = f"arg [{name}] has already been declared"
-                raise FailedToParseLaunchFile(m)
-        else:
-            arg_names = arg_names + (name,)
-
-        # decide which resolve dictionary should be used
-        use_include_resolve_dict = self.include_resolve_dict is not None
-        if use_include_resolve_dict:
-            resolve_dict = self.include_resolve_dict
-        else:
-            resolve_dict = self.resolve_dict
-
-        resolve_dict = resolve_dict.copy()
-        arg_dict = resolve_dict['arg'] = resolve_dict.get('arg', {}).copy()
-
-        if value is not None:
-            if name in arg_dict and not self.pass_all_args:
-                m = f"arg [{name}] value has already been defined."
-                raise FailedToParseLaunchFile(m)
-            arg_dict[name] = value
-        elif default is not None:
-            arg_dict[name] = arg_dict.get(name, default)
-
-        # construct new context
-        ctx = attr.evolve(self, arg_names=arg_names)
-        if use_include_resolve_dict:
-            return attr.evolve(ctx, include_resolve_dict=resolve_dict)
-        else:
-            return attr.evolve(ctx, resolve_dict=resolve_dict)
 
 
 def tag(name: str, legal_attributes: Collection[str] = tuple()):

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -117,6 +117,7 @@ class LaunchFileReader:
         package = self._read_required(tag, 'pkg', ctx)
         node_type = self._read_required(tag, 'type', ctx)
         output = self._read_optional(tag, 'output', ctx)
+        launch_prefix = self._read_optional(tag, 'launch_prefix', ctx)
         required = self._read_optional_bool(tag, 'required', ctx, False)
         respawn = self._read_optional_bool(tag, 'respawn', ctx, False)
         respawn_delay = \
@@ -138,6 +139,7 @@ class LaunchFileReader:
                           output=output,
                           remappings=ctx.remappings,
                           filename=ctx.filename,
+                          env_args=ctx.env_args,
                           typ=node_type)
         cfg = cfg.with_node(node)
         return ctx, cfg

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -266,6 +266,7 @@ class LaunchFileReader:
                           ) -> Tuple[LaunchContext, ROSConfig]:
         include_filename = self._resolve_args(tag.attrib['file'])
         logger.debug("include file: %s", include_filename)
+        cfg = cfg.with_roslaunch_file(include_filename)
 
         # construct child context
         ctx_child = self._handle_ns_and_clear_params(ctx,
@@ -342,4 +343,5 @@ class LaunchFileReader:
             ctx = ctx.with_argv(argv)
 
         launch = self._parse_file(fn)
-        return self._load_launch(ctx, cfg, launch)
+        ctx, cfg = self._load_launch(ctx, cfg, launch)
+        logger.debug("launch configuration: %s", cfg)

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -171,9 +171,7 @@ class LaunchFileReader:
                       ctx: LaunchContext,
                       tag: ET.Element
                       ) -> LaunchContext:
-        name = tag.attrib['name']
-        logger.debug("found attribute: %s", name)
-        return ctx.with_arg(name=name,
+        return ctx.with_arg(name=tag.attrib['name'],
                             value=tag.attrib.get('value'),
                             default=tag.attrib.get('default'),
                             doc=tag.attrib.get('doc'))
@@ -183,10 +181,7 @@ class LaunchFileReader:
                       ctx: LaunchContext,
                       tag: ET.Element
                       ) -> LaunchContext:
-        name = tag.attrib['name']
-        value = tag.attrib['value']
-        logger.debug("found env tag [%s]: %s", name, value)
-        return ctx.with_env_arg(name, value)
+        return ctx.with_env_arg(tag.attrib['name'], tag.attrib['value'])
 
     @tag('include', ['file', 'pass_all_args', 'ns', 'clear_params'])
     def _load_include_tag(self,

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -117,7 +117,9 @@ class LaunchFileReader:
         package = self._read_required(tag, 'pkg', ctx)
         node_type = self._read_required(tag, 'type', ctx)
         output = self._read_optional(tag, 'output', ctx)
-        launch_prefix = self._read_optional(tag, 'launch_prefix', ctx)
+        launch_prefix = self._read_optional(tag, 'launch-prefix', ctx)
+        cwd = self._read_optional(tag, 'cwd', ctx)
+        args = self._read_optional(tag, 'args', ctx)
         required = self._read_optional_bool(tag, 'required', ctx, False)
         respawn = self._read_optional_bool(tag, 'respawn', ctx, False)
         respawn_delay = \
@@ -133,11 +135,14 @@ class LaunchFileReader:
         node = NodeConfig(name=name,
                           namespace=ctx.namespace,
                           package=package,
+                          cwd=cwd,
+                          args=args,
                           required=required,
                           respawn=respawn,
                           respawn_delay=respawn_delay,
                           output=output,
                           remappings=ctx.remappings,
+                          launch_prefix=launch_prefix,
                           filename=ctx.filename,
                           env_args=ctx.env_args,
                           typ=node_type)

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -103,9 +103,7 @@ class LaunchFileReader:
                           pkg=pkg,
                           required=required,
                           typ=node_type)
-        logger.debug("found node: %s", node)
-
-        cfg = cfg.with_node(name)
+        cfg = cfg.with_node(node)
         return ctx, cfg
 
     @tag('arg', ['name', 'default', 'value', 'doc'])

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -149,7 +149,9 @@ class LaunchFileReader:
                       cfg: ROSConfig,
                       tag: ET.Element
                       ) -> Tuple[LaunchContext, ROSConfig]:
-        ctx = ctx.with_env_arg(tag.attrib['name'], tag.attrib['value'])
+        name = self._read_required(tag, 'name', ctx)
+        value = self._read_required(tag, 'value', ctx)
+        ctx = ctx.with_env_arg(name, value)
         return ctx, cfg
 
     @tag('include', ['file', 'pass_all_args', 'ns', 'clear_params'])

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -93,6 +93,7 @@ class LaunchFileReader:
         name = tag.attrib['name']
         pkg = tag.attrib['type']
         node_type = tag.attrib['type']
+        required = _parse_bool('required', tag.attrib.get('required'), False)
 
         allowed = {'remap', 'rosparam', 'env', 'param'}
         # self._load_tags([t for t in tags if t.tag in allowed])
@@ -100,6 +101,7 @@ class LaunchFileReader:
         node = NodeConfig(name=name,
                           namespace=ctx.namespace,
                           pkg=pkg,
+                          required=required,
                           typ=node_type)
         logger.debug("found node: %s", node)
 

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -160,7 +160,7 @@ class LaunchFileReader:
                           cfg: ROSConfig,
                           tag: ET.Element
                           ) -> Tuple[LaunchContext, ROSConfig]:
-        include_filename = self._resolve_args(tag.attrib['file'], ctx)
+        include_filename = self._read_required(tag, 'file', ctx)
         logger.debug("include file: %s", include_filename)
         cfg = cfg.with_roslaunch_file(include_filename)
 
@@ -171,11 +171,8 @@ class LaunchFileReader:
 
         # if instructed to pass along args, then those args must be added to
         # the child context
-        if 'pass_all_args' in tag.attrib:
-            s_pass_all_args = tag.attrib['pass_all_args'].value
-            s_pass_all_args = self._resolve_args(s_pass_all_args, ctx)
-            if _parse_bool('pass_all_args', s_pass_all_args, False):
-                ctx_child = ctx_child.with_pass_all_args()
+        if self._read_optional_bool(tag, 'pass_all_args', ctx, False):
+            ctx_child = ctx_child.with_pass_all_args()
 
         # handle child tags
         child_tags = [t for t in tag if t.tag in ('env', 'arg')]

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -306,6 +306,13 @@ class LaunchFileReader:
         """Resolves all substitution args in a given string."""
         return resolve_args(self.__shell, self.__files, s)
 
+    def _load_launch(self,
+                     ctx: LaunchContext,
+                     cfg: ROSConfig,
+                     launch: ET.Element
+                     ) -> Tuple[LaunchContext, ROSConfig]:
+        return self._load_tags(ctx, cfg, list(launch))
+
     def read(self, fn: str, argv: Optional[Sequence[str]] = None) -> None:
         """Parses the contents of a given launch file.
 
@@ -324,4 +331,4 @@ class LaunchFileReader:
             ctx = ctx.with_argv(argv)
 
         launch = self._parse_file(fn)
-        ctx, cfg = self._load_tags(ctx, cfg, list(launch))
+        return self._load_launch(ctx, cfg, launch)

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -46,6 +46,16 @@ class LaunchContext:
     env_args: Tuple[Tuple[str, str], ...] = attr.ib(default=tuple())
     pass_all_args: bool = attr.ib(default=False)
 
+    def child(self, ns: Optional[str] = None) -> 'LaunchContext':
+        """Creates a child context that inherits from this context."""
+        if ns is None:
+            child_ns = self.namespace
+        elif ns.startswith('/') or ns == '~':
+            child_ns = ns
+        else:
+            child_ns = ns_join(self.namespace, ns)
+        return attr.evolve(self, namespace=child_ns, parent=self)
+
     def with_argv(self, argv: Sequence[str]) -> 'LaunchContext':
         # ignore parameter assignment mappings
         logger.debug("loading argv: %s", argv)

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -47,11 +47,16 @@ class NodeConfig:
 class ROSConfig:
     nodes: Tuple[str, ...] = attr.ib(default=tuple())
     executables: Tuple[str, ...] = attr.ib(default=tuple())
+    roslaunch_files: Tuple[str, ...] = attr.ib(default=tuple())
 
     def with_executable(self, executable: str) -> 'ROSConfig':
         """Specify an executable that should be run at launch."""
         executables = self.executables + (executable,)
         return attr.evolve(self, executables=executables)
+
+    def with_roslaunch_file(self, filename: str) -> 'ROSConfig':
+        roslaunch_files = self.roslaunch_files + (filename,)
+        return attr.evolve(self, roslaunch_files=roslaunch_files)
 
 
 @attr.s(frozen=True, slots=True)

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -52,6 +52,7 @@ def _parse_float(attr: str, val: str) -> float:
 
 def tag(name: str, legal_attributes: Collection[str] = tuple()):
     legal_attributes = frozenset(legal_attributes)
+
     def wrap(loader):
         def wrapped(self,
                     ctx: LaunchContext,
@@ -67,6 +68,7 @@ def tag(name: str, legal_attributes: Collection[str] = tuple()):
             return ctx, cfg
         _TAG_TO_LOADER[name] = wrapped
         return wrapped
+
     return wrap
 
 
@@ -121,11 +123,11 @@ class LaunchFileReader:
         raise NotImplementedError
 
     def _read_param_binfile(self,
-                             name: str,
-                             typ: str,
-                             filename: str,
-                             ctx: LaunchContext
-                             ) -> Any:
+                            name: str,
+                            typ: str,
+                            filename: str,
+                            ctx: LaunchContext
+                            ) -> Any:
         """Reads a parameter value from a given binary file."""
         raise NotImplementedError
 

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -27,6 +27,7 @@ _TAG_TO_LOADER = {}
 
 
 def _parse_bool(attr: str, val: Optional[str], default: bool) -> bool:
+    """Parses a boolean value from an XML attribute."""
     if val is None:
         return default
 
@@ -38,6 +39,20 @@ def _parse_bool(attr: str, val: Optional[str], default: bool) -> bool:
 
     m = f'illegal boolean attribute [{attr}]: {val}'
     raise FailedToParseLaunchFile(m)
+
+
+def _parse_float(attr: str, val: Optional[str], default: float) -> float:
+    """Parses a float value from an XML attribute."""
+    if val is None:
+        return default
+    if not val:
+        m = f'empty string used by float attribute [{attr}]'
+        raise FailedToParseLaunchFile(m)
+    try:
+        return float(val)
+    except ValueError:
+        m = f'failed to parse attribute [{attr}] to float: {val}'
+        raise FailedToParseLaunchFile(m)
 
 
 def tag(name: str, legal_attributes: Collection[str] = tuple()):

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -226,6 +226,14 @@ class LaunchFileReader:
         """Reads the string value of an optional attribute of a DOM element."""
         if attrib not in elem.attrib:
             return None
+        return self._read_required(elem, attrib, ctx)
+
+    def _read_required(self,
+                       elem: ET.Element,
+                       attrib: str,
+                       ctx: LaunchContext
+                       ) -> str:
+        """Reads the string value of a required attribute of a DOM element."""
         return self._resolve_args(elem.attrib[attrib])
 
     def _resolve_args(self, s: str, ctx: LaunchContext) -> str:

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -205,9 +205,8 @@ class LaunchFileReader:
 
     def _resolve_args(self, s: str, ctx: LaunchContext) -> str:
         """Resolves all substitution args in a given string."""
-        arg_dict = ctx.resolve_dict['arg']
-        logger.debug("resolve [%s] with context: %s", s, arg_dict)
-        return resolve_args(self.__shell, self.__files, s, arg_dict)
+        logger.debug("resolve [%s] with context: %s", s, ctx.resolve_dict)
+        return resolve_args(self.__shell, self.__files, s, ctx.resolve_dict)
 
     def read(self, fn: str, argv: Optional[Sequence[str]] = None) -> None:
         """Parses the contents of a given launch file.

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -133,16 +133,14 @@ class LaunchFileReader:
                       cfg: ROSConfig,
                       tag: ET.Element
                       ) -> Tuple[LaunchContext, ROSConfig]:
-        value: Optional[str] = tag.attrib.get('value')
-        default: Optional[str] = tag.attrib.get('default')
-        if value:
-            value = self._resolve_args(value, ctx)
-        if default:
-            default = self._resolve_args(default, ctx)
-        ctx = ctx.with_arg(name=tag.attrib['name'],
+        name = self._read_required(tag, 'name', ctx)
+        value = self._read_optional(tag, 'value', ctx)
+        default = self._read_optional(tag, 'default', ctx)
+        doc = self._read_optional(tag, 'doc', ctx)
+        ctx = ctx.with_arg(name=name,
                            value=value,
                            default=default,
-                           doc=tag.attrib.get('doc'))
+                           doc=doc)
         return ctx, cfg
 
     @tag('env', ['name', 'value'])

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -134,8 +134,10 @@ class LaunchFileReader:
                       ctx: LaunchContext,
                       tag: ET.Element
                       ) -> LaunchContext:
+        name = tag.attrib['name']
+        value = tag.attrib['value']
         logger.debug("found env tag [%s]: %s", name, value)
-        return ctx.with_env_arg(tag.attrib['name'], tag.attrib['value'])
+        return ctx.with_env_arg(name, value)
 
     @tag('include', ['file', 'pass_all_args', 'ns', 'clear_params'])
     def _load_include_tag(self,

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -14,6 +14,7 @@ import attr
 from ..substitution import resolve as resolve_args
 from ..shell import ShellProxy
 from ..file import FileProxy
+from ...name import namespace_join
 from ...exceptions import FailedToParseLaunchFile
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -53,7 +54,7 @@ class LaunchContext:
         elif ns.startswith('/') or ns == '~':
             child_ns = ns
         else:
-            child_ns = ns_join(self.namespace, ns)
+            child_ns = namespace_join(self.namespace, ns)
         return attr.evolve(self, namespace=child_ns, parent=self)
 
     def with_argv(self, argv: Sequence[str]) -> 'LaunchContext':

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -84,7 +84,7 @@ class LaunchFileReader:
         return ctx, cfg
 
     @tag('node', ['name', 'type', 'pkg', 'required', 'clear_params',
-                  'namespace', 'output'])
+                  'respawn', 'namespace', 'output'])
     def _load_node_tag(self,
                        ctx: LaunchContext,
                        cfg: ROSConfig,
@@ -94,6 +94,7 @@ class LaunchFileReader:
         package = tag.attrib['pkg']
         node_type = tag.attrib['type']
         required = _parse_bool('required', tag.attrib.get('required'), False)
+        respawn = _parse_bool('respawn', tag.attrib.get('respawn'), False)
 
         allowed = {'remap', 'rosparam', 'env', 'param'}
         # self._load_tags([t for t in tags if t.tag in allowed])
@@ -105,7 +106,9 @@ class LaunchFileReader:
                           namespace=ctx.namespace,
                           package=package,
                           required=required,
+                          respawn=respawn,
                           remappings=remappings,
+                          filename=ctx.filename,
                           typ=node_type)
         cfg = cfg.with_node(node)
         return ctx, cfg

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -339,12 +339,23 @@ class LaunchFileReader:
             return default
         return _parse_bool(attrib, s)
 
+    @overload
     def _read_optional_float(self,
                              elem: ET.Element,
                              attrib: str,
                              ctx: LaunchContext,
-                             default: Optional[float] = None
-                             ) -> Optional[float]:
+                             default: None
+                             ) -> Optional[float]: ...
+
+    @overload
+    def _read_optional_float(self,
+                             elem: ET.Element,
+                             attrib: str,
+                             ctx: LaunchContext,
+                             default: float
+                             ) -> float: ...
+
+    def _read_optional_float(self, elem, attrib, ctx, default=None):
         s = self._read_optional(elem, attrib, ctx)
         if s is None:
             return default

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -12,6 +12,7 @@ import xml.etree.ElementTree as ET
 
 import attr
 
+from .config import ROSConfig, NodeConfig
 from ..substitution import resolve as resolve_args
 from ..shell import ShellProxy
 from ..file import FileProxy
@@ -22,41 +23,6 @@ logger: logging.Logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 _TAG_TO_LOADER = {}
-
-
-@attr.s(slots=True)
-class LaunchConfig:
-    nodes = attr.ib(type=List[str])
-
-
-@attr.s(frozen=True, slots=True)
-class Parameter:
-    name: str = attr.ib()
-    value: str = attr.ib()  # TODO convert to appropriate type
-
-
-@attr.s(frozen=True, slots=True)
-class NodeConfig:
-    namespace: str = attr.ib()
-    name: str = attr.ib()
-    typ: str = attr.ib()
-    pkg: str = attr.ib()
-
-
-@attr.s(frozen=True, slots=True)
-class ROSConfig:
-    nodes: Tuple[str, ...] = attr.ib(default=tuple())
-    executables: Tuple[str, ...] = attr.ib(default=tuple())
-    roslaunch_files: Tuple[str, ...] = attr.ib(default=tuple())
-
-    def with_executable(self, executable: str) -> 'ROSConfig':
-        """Specify an executable that should be run at launch."""
-        executables = self.executables + (executable,)
-        return attr.evolve(self, executables=executables)
-
-    def with_roslaunch_file(self, filename: str) -> 'ROSConfig':
-        roslaunch_files = self.roslaunch_files + (filename,)
-        return attr.evolve(self, roslaunch_files=roslaunch_files)
 
 
 @attr.s(frozen=True, slots=True)

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -93,6 +93,15 @@ class LaunchFileReader:
             ctx, cfg = loader(self, ctx, cfg, tag)
         return ctx, cfg
 
+    def _read_param_value(self,
+                          name: str,
+                          typ: str,
+                          val: str,
+                          ctx: LaunchContext
+                          ) -> Any:
+        """Reads a parameter value from a resolved string."""
+        raise NotImplementedError
+
     @tag('param', ['name', 'value', 'type', 'textfile', 'binfile', 'command'])
     def _load_param_tag(self,
                         ctx: LaunchContext,

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -115,6 +115,19 @@ class LaunchFileReader:
             m = '<param> must have exactly one value/textfile/binfile/command'
             raise FailedToParseLaunchFile(m)
 
+        value: Any
+        if val is not None:
+            value = self._read_param_value(name, typ, val, ctx)
+        if textfile is not None:
+            value = self._read_param_textfile(name, typ, val, ctx)
+        if binfile is not None:
+            value = self._read_param_binfile(name, typ, val, ctx)
+        if command is not None:
+            value = self._read_param_command(name, typ, val, ctx)
+
+        # TODO handle private/local parameters
+        # TODO handle global parameters
+
         return ctx, cfg
 
     @tag('remap', ['from', 'to'])
@@ -311,8 +324,13 @@ class LaunchFileReader:
         logger.debug("resolve [%s] with context: %s", s, ctx.resolve_dict)
         return resolve_args(self.__shell, self.__files, s, ctx.resolve_dict)
 
-    def read(self, fn: str, argv: Optional[Sequence[str]] = None) -> None:
+    def read(self, fn: str, argv: Optional[Sequence[str]] = None) -> ROSConfig:
         """Parses the contents of a given launch file.
+
+        Returns
+        -------
+        ROSConfig
+            A description of the launch configuration.
 
         Reference
         ---------
@@ -327,3 +345,4 @@ class LaunchFileReader:
         launch = self._parse_file(fn)
         ctx, cfg = self._load_tags(ctx, cfg, list(launch))
         logger.debug("launch configuration: %s", cfg)
+        return cfg

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -219,10 +219,10 @@ class LaunchFileReader:
         return ctx_child
 
     def _read_optional(self,
-                        elem: ET.Element,
-                        attrib: str,
-                        ctx: LaunchContext
-                        ) -> Optional[str]:
+                       elem: ET.Element,
+                       attrib: str,
+                       ctx: LaunchContext
+                       ) -> Optional[str]:
         """Reads the string value of an optional attribute of a DOM element."""
         if attrib not in elem.attrib:
             return None

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -226,7 +226,7 @@ class LaunchFileReader:
         """Reads the string value of an optional attribute of a DOM element."""
         if attrib not in elem.attrib:
             return None
-        return self._resolve_args(elem.attrib[val])
+        return self._resolve_args(elem.attrib[attrib])
 
     def _resolve_args(self, s: str, ctx: LaunchContext) -> str:
         """Resolves all substitution args in a given string."""

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -46,6 +46,12 @@ class NodeConfig:
 @attr.s(frozen=True, slots=True)
 class ROSConfig:
     nodes: Tuple[str, ...] = attr.ib(default=tuple())
+    executables: Tuple[str, ...] = attr.ib(default=tuple())
+
+    def with_executable(self, executable: str) -> 'ROSConfig':
+        """Specify an executable that should be run at launch."""
+        executables = self.executables + (executable,)
+        return attr.evolve(self, executables=executables)
 
 
 @attr.s(frozen=True, slots=True)

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -218,6 +218,16 @@ class LaunchFileReader:
 
         return ctx_child
 
+    def _read_optional(self,
+                        elem: ET.Element,
+                        attrib: str,
+                        ctx: LaunchContext
+                        ) -> Optional[str]:
+        """Reads the string value of an optional attribute of a DOM element."""
+        if attrib not in elem.attrib:
+            return None
+        return self._resolve_args(elem.attrib[val])
+
     def _resolve_args(self, s: str, ctx: LaunchContext) -> str:
         """Resolves all substitution args in a given string."""
         logger.debug("resolve [%s] with context: %s", s, ctx.resolve_dict)

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -101,9 +101,7 @@ class LaunchFileReader:
                         ) -> Tuple[LaunchContext, ROSConfig]:
         frm = self._read_required(tag, 'from', ctx)
         to = self._read_required(tag, 'to', ctx)
-        logger.debug("remapping: %s -> %s", frm, to)
-
-        # TODO add remap to context
+        ctx = ctx.with_remapping(frm, to)
         return ctx, cfg
 
     @tag('node', ['name', 'type', 'pkg', 'required', 'clear_params',

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -70,10 +70,13 @@ def tag(name: str, legal_attributes: Collection[str] = tuple()):
                     ctx: LaunchContext,
                     elem: ET.Element
                     ) -> LaunchContext:
+            logger.debug("parsing <%s> tag", name)
             for attribute in elem.attrib:
                 if attribute not in legal_attributes:
                     raise FailedToParseLaunchFile(m)
-            return loader(self, ctx, elem)
+            ctx = loader(self, ctx, elem)
+            logger.debug("new context: %s", ctx)
+            return ctx
         _TAG_TO_LOADER[name] = wrapped
         return wrapped
     return wrap

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -142,15 +142,12 @@ class LaunchFileReader:
                                                      tag,
                                                      include_filename=include_filename)
 
-        # TODO handle with_pass_all_args
         # if instructed to pass along args, then those args must be added to
         # the child context
-
         if 'pass_all_args' in tag.attrib:
-            # TODO resolve and convert to boolean
-            pass_all_args_s = tag.attrib['pass_all_args'].value
-            pass_all_args = self._resolve_args(pass_all_args_s)
-            if pass_all_args:
+            s_pass_all_args = tag.attrib['pass_all_args'].value
+            s_pass_all_args = self._resolve_args(s_pass_all_args)
+            if _parse_bool('pass_all_args', s_pass_all_args, False):
                 ctx_child = ctx_child.with_pass_all_args()
 
         # handle child tags

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -91,17 +91,21 @@ class LaunchFileReader:
                        tag: ET.Element
                        ) -> Tuple[LaunchContext, ROSConfig]:
         name = tag.attrib['name']
-        pkg = tag.attrib['type']
+        package = tag.attrib['pkg']
         node_type = tag.attrib['type']
         required = _parse_bool('required', tag.attrib.get('required'), False)
 
         allowed = {'remap', 'rosparam', 'env', 'param'}
         # self._load_tags([t for t in tags if t.tag in allowed])
 
+        # TODO determine remappings
+        remappings = tuple()
+
         node = NodeConfig(name=name,
                           namespace=ctx.namespace,
-                          pkg=pkg,
+                          package=package,
                           required=required,
+                          remappings=remappings,
                           typ=node_type)
         cfg = cfg.with_node(node)
         return ctx, cfg

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -99,7 +99,34 @@ class LaunchFileReader:
                           val: str,
                           ctx: LaunchContext
                           ) -> Any:
-        """Reads a parameter value from a resolved string."""
+        """Reads a parameter value from a resolved value string."""
+        raise NotImplementedError
+
+    def _read_param_command(self,
+                            name: str,
+                            typ: str,
+                            command: str,
+                            ctx: LaunchContext
+                            ) -> Any:
+        """Reads a parameter value from a resolved command string."""
+        raise NotImplementedError
+
+    def _read_param_textfile(self,
+                             name: str,
+                             typ: str,
+                             filename: str,
+                             ctx: LaunchContext
+                             ) -> Any:
+        """Reads a parameter value from a given text file."""
+        raise NotImplementedError
+
+    def _read_param_binfile(self,
+                             name: str,
+                             typ: str,
+                             filename: str,
+                             ctx: LaunchContext
+                             ) -> Any:
+        """Reads a parameter value from a given binary file."""
         raise NotImplementedError
 
     @tag('param', ['name', 'value', 'type', 'textfile', 'binfile', 'command'])

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -44,6 +44,11 @@ class NodeConfig:
 
 
 @attr.s(frozen=True, slots=True)
+class ROSConfig:
+    nodes: Tuple[str, ...] = attr.ib(default=tuple())
+
+
+@attr.s(frozen=True, slots=True)
 class LaunchContext:
     filename: str = attr.ib()
     resolve_dict: Mapping[str, Any] = attr.ib()
@@ -163,15 +168,16 @@ def tag(name: str, legal_attributes: Collection[str] = tuple()):
     def wrap(loader):
         def wrapped(self,
                     ctx: LaunchContext,
+                    cfg: ROSConfig,
                     elem: ET.Element
-                    ) -> LaunchContext:
+                    ) -> Tuple[LaunchContext, ROSConfig]:
             logger.debug("parsing <%s> tag", name)
             for attribute in elem.attrib:
                 if attribute not in legal_attributes:
                     raise FailedToParseLaunchFile(m)
-            ctx = loader(self, ctx, elem)
+            ctx, cfg = loader(self, ctx, cfg, elem)
             logger.debug("new context: %s", ctx)
-            return ctx
+            return ctx, cfg
         _TAG_TO_LOADER[name] = wrapped
         return wrapped
     return wrap
@@ -192,18 +198,20 @@ class LaunchFileReader:
 
     def _load_tags(self,
                    ctx: LaunchContext,
+                   cfg: ROSConfig,
                    tags: Sequence[ET.Element]
                    ) -> LaunchContext:
         for tag in (t for t in tags if t.tag in _TAG_TO_LOADER):
             loader = _TAG_TO_LOADER[tag.tag]
-            ctx = loader(self, ctx, tag)
-        return ctx
+            ctx, cfg = loader(self, ctx, cfg, tag)
+        return ctx, cfg
 
     @tag('arg', ['name', 'type', 'pkg'])
     def _load_node_tag(self,
                        ctx: LaunchContext,
+                       cfg: ROSConfig,
                        tag: ET.Element
-                       ) -> LaunchContext:
+                       ) -> Tuple[LaunchContext, ROSConfig]:
         name = tag.attrib['name']
         pkg = tag.attrib['type']
         node_type = tag.attrib['type']
@@ -216,30 +224,35 @@ class LaunchFileReader:
                           pkg=pkg,
                           node_type=node_type)
         logger.debug("found node: %s", node)
-        return ctx
+        return ctx, cfg
 
     @tag('arg', ['name', 'default', 'value', 'doc'])
     def _load_arg_tag(self,
                       ctx: LaunchContext,
+                      cfg: ROSConfig,
                       tag: ET.Element
-                      ) -> LaunchContext:
-        return ctx.with_arg(name=tag.attrib['name'],
-                            value=tag.attrib.get('value'),
-                            default=tag.attrib.get('default'),
-                            doc=tag.attrib.get('doc'))
+                      ) -> Tuple[LaunchContext, ROSConfig]:
+        ctx = ctx.with_arg(name=tag.attrib['name'],
+                           value=tag.attrib.get('value'),
+                           default=tag.attrib.get('default'),
+                           doc=tag.attrib.get('doc'))
+        return ctx, cfg
 
     @tag('env', ['name', 'value'])
     def _load_env_tag(self,
                       ctx: LaunchContext,
+                      cfg: ROSConfig,
                       tag: ET.Element
-                      ) -> LaunchContext:
-        return ctx.with_env_arg(tag.attrib['name'], tag.attrib['value'])
+                      ) -> Tuple[LaunchContext, ROSConfig]:
+        ctx = ctx.with_env_arg(tag.attrib['name'], tag.attrib['value'])
+        return ctx, cfg
 
     @tag('include', ['file', 'pass_all_args', 'ns', 'clear_params'])
     def _load_include_tag(self,
                           ctx: LaunchContext,
+                          cfg: ROSConfig,
                           tag: ET.Element
-                          ) -> LaunchContext:
+                          ) -> Tuple[LaunchContext, ROSConfig]:
         include_filename = self._resolve_args(tag.attrib['file'])
         logger.debug("include file: %s", include_filename)
 
@@ -261,10 +274,11 @@ class LaunchFileReader:
 
         # handle child tags
         child_tags = [t for t in tag if t.tag in ('env', 'arg')]
-        ctx_child = self._load_tags(ctx_child, child_tags)
+        ctx_child, cfg = self._load_tags(ctx_child, cfg, child_tags)
         ctx_child = ctx_child.process_include_args()
+        logger.debug("prepared include context: %s", ctx_child)
 
-        return ctx
+        return ctx, cfg
 
     def _handle_ns_and_clear_params(self,
                                     ctx: LaunchContext,
@@ -300,6 +314,7 @@ class LaunchFileReader:
             http://wiki.ros.org/roslaunch/XML/node
             http://docs.ros.org/kinetic/api/roslaunch/html/roslaunch.xmlloader.XmlLoader-class.html
         """
+        cfg = ROSConfig()
         ctx = LaunchContext(namespace='/',
                             filename=fn,
                             resolve_dict={},
@@ -309,4 +324,4 @@ class LaunchFileReader:
             ctx = ctx.with_argv(argv)
 
         launch = self._parse_file(fn)
-        self._load_tags(ctx, list(launch))
+        ctx, cfg = self._load_tags(ctx, cfg, list(launch))

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -139,8 +139,8 @@ class LaunchContext:
         else:
             resolve_dict = self.resolve_dict
 
-        resolve_dict = deepcopy(resolve_dict)
-        arg_dict = resolve_dict['arg']
+        resolve_dict = resolve_dict.copy()
+        arg_dict = resolve_dict['arg'] = resolve_dict.get('arg', {}).copy()
 
         if value is not None:
             if name in arg_dict and not self.pass_all_args:

--- a/src/roswire/proxy/launch/__init__.py
+++ b/src/roswire/proxy/launch/__init__.py
@@ -238,7 +238,7 @@ class LaunchFileReader:
             elif not ns:
                 m = "'ns' must be specified to use 'clear_params'"
                 raise FailedToParseLaunchFile(m)
-            cfg = cfg.with_cleared_params(clear_ns)
+            cfg = cfg.with_clear_params(clear_ns)
 
         return ctx_child, cfg
 

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -4,7 +4,7 @@ This file provides data structures that represent ROS launch configurations.
 """
 __all__ = ('ROSConfig', 'NodeConfig')
 
-from typing import Tuple, FrozenSet
+from typing import Tuple, FrozenSet, Optional
 import logging
 
 import attr
@@ -29,7 +29,9 @@ class NodeConfig:
     typ: str = attr.ib()
     package: str = attr.ib()
     remappings: Tuple[str, ...] = attr.ib(converter=tuple, default=tuple())
+    filename: Optional[str] = attr.ib(default=None)
     required: bool = attr.ib(default=False)
+    respawn: bool = attr.ib(default=False)
 
     @property
     def full_name(self) -> str:

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -47,6 +47,10 @@ class ROSConfig:
     executables: Tuple[str, ...] = attr.ib(default=tuple())
     roslaunch_files: Tuple[str, ...] = attr.ib(default=tuple())
 
+    def with_cleared_params(self, ns: str) -> 'ROSConfig':
+        logger.warning("unimplemented functionality [with_cleared_params]")
+        return self
+
     def with_executable(self, executable: str) -> 'ROSConfig':
         """Specify an executable that should be run at launch."""
         executables = self.executables + (executable,)

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -27,7 +27,8 @@ class NodeConfig:
     namespace: str = attr.ib()
     name: str = attr.ib()
     typ: str = attr.ib()
-    pkg: str = attr.ib()
+    package: str = attr.ib()
+    remappings: Tuple[str, ...] = attr.ib(converter=tuple, default=tuple())
     required: bool = attr.ib(default=False)
 
     @property

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -37,3 +37,7 @@ class ROSConfig:
     def with_roslaunch_file(self, filename: str) -> 'ROSConfig':
         roslaunch_files = self.roslaunch_files + (filename,)
         return attr.evolve(self, roslaunch_files=roslaunch_files)
+
+    def with_node(self, name: str) -> 'ROSConfig':
+        nodes = self.nodes + (name,)
+        return attr.evolve(self, nodes=nodes)

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -33,6 +33,7 @@ class NodeConfig:
     output: Optional[str] = attr.ib(default=None)
     required: bool = attr.ib(default=False)
     respawn: bool = attr.ib(default=False)
+    respawn_delay: float = attr.ib(default=0.0)
 
     @property
     def full_name(self) -> str:

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+This file provides data structures that represent ROS launch configurations.
+"""
+__all__ = ('ROSConfig', 'NodeConfig')
+
+from typing import Tuple
+
+import attr
+
+
+@attr.s(frozen=True, slots=True)
+class Parameter:
+    name: str = attr.ib()
+    value: str = attr.ib()  # TODO convert to appropriate type
+
+
+@attr.s(frozen=True, slots=True)
+class NodeConfig:
+    namespace: str = attr.ib()
+    name: str = attr.ib()
+    typ: str = attr.ib()
+    pkg: str = attr.ib()
+
+
+@attr.s(frozen=True, slots=True)
+class ROSConfig:
+    nodes: Tuple[str, ...] = attr.ib(default=tuple())
+    executables: Tuple[str, ...] = attr.ib(default=tuple())
+    roslaunch_files: Tuple[str, ...] = attr.ib(default=tuple())
+
+    def with_executable(self, executable: str) -> 'ROSConfig':
+        """Specify an executable that should be run at launch."""
+        executables = self.executables + (executable,)
+        return attr.evolve(self, executables=executables)
+
+    def with_roslaunch_file(self, filename: str) -> 'ROSConfig':
+        roslaunch_files = self.roslaunch_files + (filename,)
+        return attr.evolve(self, roslaunch_files=roslaunch_files)

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -21,6 +21,7 @@ class NodeConfig:
     name: str = attr.ib()
     typ: str = attr.ib()
     pkg: str = attr.ib()
+    required: bool = attr.ib(default=False)
 
 
 @attr.s(frozen=True, slots=True)

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -30,6 +30,7 @@ class NodeConfig:
     package: str = attr.ib()
     remappings: Tuple[str, ...] = attr.ib(converter=tuple, default=tuple())
     filename: Optional[str] = attr.ib(default=None)
+    output: Optional[str] = attr.ib(default=None)
     required: bool = attr.ib(default=False)
     respawn: bool = attr.ib(default=False)
 

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -34,6 +34,7 @@ class NodeConfig:
     required: bool = attr.ib(default=False)
     respawn: bool = attr.ib(default=False)
     respawn_delay: float = attr.ib(default=0.0)
+    env_args: Tuple[Tuple[str, str], ...] = attr.ib(default=tuple())
 
     @property
     def full_name(self) -> str:

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -35,6 +35,9 @@ class NodeConfig:
     respawn: bool = attr.ib(default=False)
     respawn_delay: float = attr.ib(default=0.0)
     env_args: Tuple[Tuple[str, str], ...] = attr.ib(default=tuple())
+    cwd: Optional[str] = attr.ib(default=None)
+    args: Optional[str] = attr.ib(default=None)
+    launch_prefix: Optional[str] = attr.ib(default=None)
 
     @property
     def full_name(self) -> str:

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -9,6 +9,7 @@ import logging
 
 import attr
 
+from ...util import build_tuple
 from ...exceptions import FailedToParseLaunchFile
 from ...name import namespace_join, canonical_name
 
@@ -28,7 +29,7 @@ class NodeConfig:
     name: str = attr.ib()
     typ: str = attr.ib()
     package: str = attr.ib()
-    remappings: Tuple[str, ...] = attr.ib(converter=tuple, default=tuple())
+    remappings: Tuple[Tuple[str, str], ...] = attr.ib(default=tuple())
     filename: Optional[str] = attr.ib(default=None)
     output: Optional[str] = attr.ib(default=None)
     required: bool = attr.ib(default=False)

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -10,7 +10,7 @@ import logging
 import attr
 
 from ...exceptions import FailedToParseLaunchFile
-from ...name import namespace_join
+from ...name import namespace_join, canonical_name
 
 logger: logging.Logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -50,10 +50,18 @@ class ROSConfig:
                                            converter=frozenset)
     executables: Tuple[str, ...] = attr.ib(default=tuple())
     roslaunch_files: Tuple[str, ...] = attr.ib(default=tuple())
+    clear_params: Tuple[str, ...] = attr.ib(default=tuple())
 
-    def with_cleared_params(self, ns: str) -> 'ROSConfig':
-        logger.warning("unimplemented functionality [with_cleared_params]")
-        return self
+    def with_clear_param(self, ns: str) -> 'ROSConfig':
+        """
+        Specifies a parameter that should be cleared before new parameters
+        are set.
+        """
+        ns = canonical_name(ns)
+        if ns in self.clear_params:
+            return self
+        clear_params = self.clear_params + (ns,)
+        return attr.evolve(self, clear_params=clear_params)
 
     def with_executable(self, executable: str) -> 'ROSConfig':
         """Specify an executable that should be run at launch."""

--- a/src/roswire/proxy/launch/config.py
+++ b/src/roswire/proxy/launch/config.py
@@ -4,9 +4,16 @@ This file provides data structures that represent ROS launch configurations.
 """
 __all__ = ('ROSConfig', 'NodeConfig')
 
-from typing import Tuple
+from typing import Tuple, FrozenSet
+import logging
 
 import attr
+
+from ...exceptions import FailedToParseLaunchFile
+from ...name import namespace_join
+
+logger: logging.Logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 @attr.s(frozen=True, slots=True)
@@ -23,10 +30,15 @@ class NodeConfig:
     pkg: str = attr.ib()
     required: bool = attr.ib(default=False)
 
+    @property
+    def full_name(self) -> str:
+        return namespace_join(self.namespace, self.name)
+
 
 @attr.s(frozen=True, slots=True)
 class ROSConfig:
-    nodes: Tuple[str, ...] = attr.ib(default=tuple())
+    nodes: FrozenSet[NodeConfig] = attr.ib(default=frozenset(),
+                                           converter=frozenset)
     executables: Tuple[str, ...] = attr.ib(default=tuple())
     roslaunch_files: Tuple[str, ...] = attr.ib(default=tuple())
 
@@ -39,6 +51,13 @@ class ROSConfig:
         roslaunch_files = self.roslaunch_files + (filename,)
         return attr.evolve(self, roslaunch_files=roslaunch_files)
 
-    def with_node(self, name: str) -> 'ROSConfig':
-        nodes = self.nodes + (name,)
+    def with_node(self, node: NodeConfig) -> 'ROSConfig':
+        logger.debug("adding node to config: %s", node)
+        full_name = node.full_name
+        used_names = {n.full_name for n in self.nodes}
+        if node.full_name in used_names:
+            m = 'multiple definitions of node [{}] in launch configuration'
+            m = m.format(node.full_name)
+            raise FailedToParseLaunchFile(m)
+        nodes = self.nodes | frozenset({node})
         return attr.evolve(self, nodes=nodes)

--- a/src/roswire/proxy/launch/context.py
+++ b/src/roswire/proxy/launch/context.py
@@ -33,7 +33,7 @@ class LaunchContext:
         ctx = attr.evolve(ctx,
                           filename=filename,
                           arg_names=tuple(),
-                          include_resolve_dict=None)
+                          include_resolve_dict={})
         return ctx
 
     def child(self, ns: Optional[str] = None) -> 'LaunchContext':

--- a/src/roswire/proxy/launch/context.py
+++ b/src/roswire/proxy/launch/context.py
@@ -10,6 +10,8 @@ import logging
 
 import attr
 
+from ...name import canonical_name
+
 logger: logging.Logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -24,6 +26,7 @@ class LaunchContext:
     env_args: Tuple[Tuple[str, str], ...] = attr.ib(default=tuple())
     pass_all_args: bool = attr.ib(default=False)
     include_resolve_dict: Optional[Mapping[str, Any]] = attr.ib(default=None)
+    remappings: Tuple[Tuple[str, str], ...] = attr.ib(default=tuple())
 
     def include_child(self,
                       ns: Optional[str],
@@ -48,6 +51,12 @@ class LaunchContext:
                            namespace=child_ns,
                            parent=self,
                            pass_all_args=False)
+
+    def with_remapping(self, frm: str, to: str) -> 'LaunchContext':
+        # TODO canonicalise name
+        frm = canonical_name(frm)
+        to = canonical_name(to)
+        return self
 
     def with_pass_all_args(self) -> 'LaunchContext':
         ctx = self

--- a/src/roswire/proxy/launch/context.py
+++ b/src/roswire/proxy/launch/context.py
@@ -54,6 +54,7 @@ class LaunchContext:
                            pass_all_args=False)
 
     def with_remapping(self, frm: str, to: str) -> 'LaunchContext':
+        """Adds a name remapping."""
         frm = canonical_name(frm)
         to = canonical_name(to)
         if not frm or not to:
@@ -68,7 +69,11 @@ class LaunchContext:
             m = f"<remap>: invalid ROS name [to]: {to}"
             raise FailedToParseLaunchFile(m)
 
-        return self
+        # overwrite any existing remapping from the given source before adding
+        # the given remapping
+        remappings = tuple(r for r in self.remappings if r[0] != frm)
+        remappings = remappings + ((frm, to), )
+        return attr.evolve(self, remappings=remappings)
 
     def with_pass_all_args(self) -> 'LaunchContext':
         ctx = self

--- a/src/roswire/proxy/launch/context.py
+++ b/src/roswire/proxy/launch/context.py
@@ -86,7 +86,7 @@ class LaunchContext:
 
         arg_dict = self.include_resolve_dict.get('arg', {})
         for arg in self.arg_names:
-            if not arg in arg_dict:
+            if arg not in arg_dict:
                 m = f'include arg [{arg}] is missing value.'
                 raise FailedToParseLaunchFile(m)
 

--- a/src/roswire/proxy/launch/context.py
+++ b/src/roswire/proxy/launch/context.py
@@ -11,6 +11,7 @@ import logging
 import attr
 
 from ...name import canonical_name
+from ...exceptions import FailedToParseLaunchFile
 
 logger: logging.Logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -53,9 +54,20 @@ class LaunchContext:
                            pass_all_args=False)
 
     def with_remapping(self, frm: str, to: str) -> 'LaunchContext':
-        # TODO canonicalise name
         frm = canonical_name(frm)
         to = canonical_name(to)
+        if not frm or not to:
+            m = "'from' and 'to' attributes must be specified for <remap>"
+            raise FailedToParseLaunchFile(m)
+        # TODO check name legality
+        if False:
+            m = f"<remap>: invalid ROS name [from]: {frm}"
+            raise FailedToParseLaunchFile(m)
+        # TODO check name legality
+        if False:
+            m = f"<remap>: invalid ROS name [to]: {to}"
+            raise FailedToParseLaunchFile(m)
+
         return self
 
     def with_pass_all_args(self) -> 'LaunchContext':

--- a/src/roswire/proxy/launch/context.py
+++ b/src/roswire/proxy/launch/context.py
@@ -17,13 +17,13 @@ logger.setLevel(logging.DEBUG)
 @attr.s(frozen=True, slots=True)
 class LaunchContext:
     filename: str = attr.ib()
-    resolve_dict: Mapping[str, Any] = attr.ib()
-    include_resolve_dict: Mapping[str, Any] = attr.ib()
+    resolve_dict: Mapping[str, Any] = attr.ib(factory=dict)
     parent: 'LaunchContext' = attr.ib(default=None)
     namespace: str = attr.ib(default='/')
     arg_names: Tuple[str, ...] = attr.ib(default=tuple())
     env_args: Tuple[Tuple[str, str], ...] = attr.ib(default=tuple())
     pass_all_args: bool = attr.ib(default=False)
+    include_resolve_dict: Optional[Mapping[str, Any]] = attr.ib(default=None)
 
     def include_child(self,
                       ns: Optional[str],
@@ -33,7 +33,7 @@ class LaunchContext:
         ctx = attr.evolve(ctx,
                           filename=filename,
                           arg_names=tuple(),
-                          include_resolve_dict={})
+                          include_resolve_dict=None)
         return ctx
 
     def child(self, ns: Optional[str] = None) -> 'LaunchContext':

--- a/src/roswire/proxy/launch/context.py
+++ b/src/roswire/proxy/launch/context.py
@@ -10,7 +10,7 @@ import logging
 
 import attr
 
-from ...name import canonical_name
+from ...name import canonical_name, name_is_legal
 from ...exceptions import FailedToParseLaunchFile
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -60,12 +60,10 @@ class LaunchContext:
         if not frm or not to:
             m = "'from' and 'to' attributes must be specified for <remap>"
             raise FailedToParseLaunchFile(m)
-        # TODO check name legality
-        if False:
+        if not name_is_legal(frm):
             m = f"<remap>: invalid ROS name [from]: {frm}"
             raise FailedToParseLaunchFile(m)
-        # TODO check name legality
-        if False:
+        if not name_is_legal(to):
             m = f"<remap>: invalid ROS name [to]: {to}"
             raise FailedToParseLaunchFile(m)
 

--- a/src/roswire/proxy/launch/context.py
+++ b/src/roswire/proxy/launch/context.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""
+This file provides data structures that represent ROS launch configurations.
+"""
+__all__ = ('LaunchContext',)
+
+from typing import Tuple, Mapping, Any, Optional, Sequence
+from copy import deepcopy
+import logging
+
+import attr
+
+logger: logging.Logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+@attr.s(frozen=True, slots=True)
+class LaunchContext:
+    filename: str = attr.ib()
+    resolve_dict: Mapping[str, Any] = attr.ib()
+    include_resolve_dict: Mapping[str, Any] = attr.ib()
+    parent: 'LaunchContext' = attr.ib(default=None)
+    namespace: str = attr.ib(default='/')
+    arg_names: Tuple[str, ...] = attr.ib(default=tuple())
+    env_args: Tuple[Tuple[str, str], ...] = attr.ib(default=tuple())
+    pass_all_args: bool = attr.ib(default=False)
+
+    def include_child(self,
+                      ns: Optional[str],
+                      filename: str
+                      ) -> 'LaunchContext':
+        ctx = self.child(ns)
+        ctx = attr.evolve(ctx,
+                          filename=filename,
+                          arg_names=tuple(),
+                          include_resolve_dict={})
+        return ctx
+
+    def child(self, ns: Optional[str] = None) -> 'LaunchContext':
+        """Creates a child context that inherits from this context."""
+        if ns is None:
+            child_ns = self.namespace
+        elif ns.startswith('/') or ns == '~':
+            child_ns = ns
+        else:
+            child_ns = namespace_join(self.namespace, ns)
+        return attr.evolve(self,
+                           namespace=child_ns,
+                           parent=self,
+                           pass_all_args=False)
+
+    def with_pass_all_args(self) -> 'LaunchContext':
+        ctx = self
+        if 'arg' in self.parent.resolve_dict:
+            for var, val in self.parent.resolve_dict['arg'].items():
+                ctx = ctx.with_arg(var, value=val)
+        return attrs.evolve(ctx, pass_all_args=True)
+
+    def process_include_args(self) -> 'LaunchContext':
+        if self.include_resolve_dict is None:
+            return attr.evolve(self, arg_names=tuple())
+
+        arg_dict = self.include_resolve_dict.get('arg', {})
+        for arg in self.arg_names:
+            if not arg in arg_dict:
+                m = f'include arg [{arg}] is missing value.'
+                raise FailedToParseLaunchFile(m)
+
+        return attr.evolve(self,
+                           arg_names=tuple(),
+                           resolve_dict=deepcopy(self.include_resolve_dict),
+                           include_resolve_dict=None)
+
+    def with_argv(self, argv: Sequence[str]) -> 'LaunchContext':
+        # ignore parameter assignment mappings
+        logger.debug("loading argv: %s", argv)
+        mappings: Dict[str, str] = {}
+        for arg in (a for a in argv if ':=' in a):
+            var, sep, val = [a.strip() for a in arg.partition(':=')]
+            if not var.startswith('__'):
+                mappings[var] = val
+        logger.debug("loaded argv: %s", mappings)
+        resolve_dict = self.resolve_dict.copy()
+        resolve_dict['arg'] = mappings
+        return attr.evolve(self, resolve_dict=resolve_dict)
+
+    def with_env_arg(self, var: str, val: Any) -> 'LaunchContext':
+        env_args = self.env_args + ((var, val),)
+        return attr.evolve(self, env_args=env_args)
+
+    def with_arg(self,
+                 name: str,
+                 default: Optional[Any] = None,
+                 value: Optional[Any] = None,
+                 doc: Optional = None
+                 ) -> 'LaunchContext':
+        logger.debug("adding arg [%s] to context", name)
+        arg_names = self.arg_names
+        if name in self.arg_names:
+            if not self.pass_all_args:
+                m = f"arg [{name}] has already been declared"
+                raise FailedToParseLaunchFile(m)
+        else:
+            arg_names = arg_names + (name,)
+
+        # decide which resolve dictionary should be used
+        use_include_resolve_dict = self.include_resolve_dict is not None
+        if use_include_resolve_dict:
+            resolve_dict = self.include_resolve_dict
+        else:
+            resolve_dict = self.resolve_dict
+
+        resolve_dict = resolve_dict.copy()
+        arg_dict = resolve_dict['arg'] = resolve_dict.get('arg', {}).copy()
+
+        if value is not None:
+            if name in arg_dict and not self.pass_all_args:
+                m = f"arg [{name}] value has already been defined."
+                raise FailedToParseLaunchFile(m)
+            arg_dict[name] = value
+        elif default is not None:
+            arg_dict[name] = arg_dict.get(name, default)
+
+        # construct new context
+        ctx = attr.evolve(self, arg_names=arg_names)
+        if use_include_resolve_dict:
+            return attr.evolve(ctx, include_resolve_dict=resolve_dict)
+        else:
+            return attr.evolve(ctx, resolve_dict=resolve_dict)

--- a/src/roswire/util.py
+++ b/src/roswire/util.py
@@ -1,7 +1,16 @@
-__all__ = ('Stopwatch',)
+# -*- coding: utf-8 -*-
+__all__ = ('build_tuple', 'Stopwatch',)
 
+from typing import TypeVar, Sequence, Tuple
 from timeit import default_timer as timer
 import warnings
+
+T = TypeVar('T')
+
+
+def build_tuple(elements: Sequence[T]) -> Tuple[T, ...]:
+    """Tranforms a sequence of items to a tuple."""
+    return tuple(elements)
 
 
 class Stopwatch:

--- a/test/test_name.py
+++ b/test/test_name.py
@@ -15,6 +15,19 @@ def test_global_name():
     assert f('/foo/bar/') == '/foo/bar/'
 
 
+def test_canonical_name():
+    f = roswire.name.canonical_name
+    assert f('') == ''
+    assert f('/') == '/'
+    assert f('foo') == 'foo'
+    assert f('foo/') == 'foo'
+    assert f('/foo') == '/foo'
+    assert f('/foo/') == '/foo'
+    assert f('foo/bar') == 'foo/bar'
+    assert f('foo/bar/') == 'foo/bar'
+    assert f('/foo/bar/') == '/foo/bar'
+
+
 def test_name_is_private():
     f = roswire.name.name_is_private
     assert not f('')


### PR DESCRIPTION
This PR implements a relatively basic launch file parser that correctly handles a subset of launch file logic. Notably, there is no support for `ifunless` attributes (#246), and `param` (#256)  and `rosparam` (#257) tags.