### PR TITLE
Added -p0 option to patch command

### DIFF
--- a/src/roswire/proxy/file.py
+++ b/src/roswire/proxy/file.py
@@ -541,7 +541,7 @@ class FileProxy:
             safe_context = shlex.quote(context)
             safe_fn_diff = shlex.quote(fn_diff)
             if self.isdir(context):
-                cmd = f'patch -u -f -i {safe_fn_diff} -d {safe_context}'
+                cmd = f'patch -u -p0 -f -i {safe_fn_diff} -d {safe_context}'
             elif self.isfile(context):
                 cmd = f'patch -u -f -i {safe_fn_diff} {safe_context}'
             else:


### PR DESCRIPTION
```
root@494e0446847a:/ros_ws/src/ArduPilot# patch -i cool.diff 
can't find file to patch at input line 3
Perhaps you should have used the -p or --strip option?
The text leading up to this was:
--------------------------
|--- ArduCopter/ArduCopter.cpp
|+++ ArduCopter/ArduCopter.cpp
--------------------------
File to patch: ^C
root@494e0446847a:/ros_ws/src/ArduPilot# patch -p0 -i cool.diff 
patching file ArduCopter/ArduCopter.cpp
Hunk #1 succeeded at 326 with fuzz 1
```