### PR TITLE
Find binary location of a node specified by its type (fixes #390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Added a partial implementation of ROS2LaunchManager for launching ROS2 
   applications (fixes #377)
 * Added a common interface for ROS1 and ROS2 nodes.
+* Added binary location and assumed language to node descriptions in the
+  ROS1 launch file reader.
 
 # 1.4.0 (2020-06-25)
 


### PR DESCRIPTION
Sometimes the script name is specified by `type` tag rather than node's name.