### PR TITLE
Implemented param delete (fixes #387)

### DIFF
--- a/src/roswire/common/launch/config/launch.py
+++ b/src/roswire/common/launch/config/launch.py
@@ -99,6 +99,20 @@ class LaunchConfig:
         params[name] = param
         return attr.evolve(self, params=params, errors=errors)
 
+    def without_param(self, name: str) -> "LaunchConfig":
+        params: Dict[str, Any] = dict(self.params)
+        errors = self.errors
+
+        if not name_is_global(name):
+            m = f"expected parameter name to be global: {name}"
+            raise FailedToParseLaunchFile(m)
+        if name not in params:
+            err = f"parameter [{name}] is not in the context"
+            errors = tuple(errors) + (err,)
+        else:
+            del params[name]
+        return attr.evolve(self, params=params, errors=errors)
+
     def with_remappings(
         self,
         node_to_remappings: Mapping[str, Collection[Tuple[str, str]]],  # noqa

--- a/src/roswire/ros1/launch/reader.py
+++ b/src/roswire/ros1/launch/reader.py
@@ -277,8 +277,7 @@ class ROS1LaunchFileReader(LaunchFileReader):
 
         # handle delete command
         if cmd == "delete":
-            m = "'delete' command is currently not supported in <rosparam>"
-            raise NotImplementedError(m)
+            cfg = cfg.without_param(name=full_param)
 
         return ctx, cfg
 


### PR DESCRIPTION
The fetch example uses param delete, so it is needed for rosdiscover.