### PR TITLE
Prepared for separation of SystemState into ROS-specific versions.

### DIFF
--- a/src/roswire/common/state.py
+++ b/src/roswire/common/state.py
@@ -1,46 +1,33 @@
 # -*- coding: utf-8 -*-
 __all__ = ("SystemState",)
 
-from typing import AbstractSet, Collection, Mapping, Set
+from abc import ABC, abstractmethod
+from typing import AbstractSet, Collection, Mapping
 
-import attr
 
+class SystemState(ABC):
 
-@attr.s(frozen=True, auto_attribs=True, slots=True)
-class SystemState:
-    """Provides a description of the instantaneous state of a ROS system in
-    terms of its publishers, subscribers, and services.
+    @property
+    @abstractmethod
+    def publishers(self) -> Mapping[str, Collection[str]]:
+        ...
 
-    Attributes
-    ----------
-    publishers: Mapping[str, Collection[str]]
-        A mapping from topics to the names of publishers to that topic.
-    subscribers: Mapping[str, Collection[str]]
-        A mapping from topics to the names of subscribers to that topic.
-    services: Mapping[str, Collection[str]]
-        A mapping from services to the names of providers of that service.
-    nodes: AbstractSet[str]
-        The names of all known nodes running on the system.
-    topics: AbstractSet[str]
-        The names of all known topics on the system with at least one
-        publisher or one subscriber.
-    """
+    @property
+    @abstractmethod
+    def subscribers(self) -> Mapping[str, Collection[str]]:
+        ...
 
-    publishers: Mapping[str, Collection[str]]
-    subscribers: Mapping[str, Collection[str]]
-    services: Mapping[str, Collection[str]]
-    nodes: AbstractSet[str] = attr.ib(init=False, repr=False)
-    topics: AbstractSet[str] = attr.ib(init=False, repr=False)
+    @property
+    @abstractmethod
+    def services(self) -> Mapping[str, Collection[str]]:
+        ...
 
-    def __attrs_post_init__(self) -> None:
-        nodes: Set[str] = set()
-        nodes = nodes.union(*self.publishers.values())
-        nodes = nodes.union(*self.subscribers.values())
-        nodes = nodes.union(*self.services.values())
+    @property
+    @abstractmethod
+    def nodes(self) -> AbstractSet[str]:
+        ...
 
-        topics: Set[str] = set()
-        topics = topics.union(self.publishers)
-        topics = topics.union(self.subscribers)
-
-        object.__setattr__(self, "nodes", frozenset(nodes))
-        object.__setattr__(self, "topics", frozenset(topics))
+    @property
+    @abstractmethod
+    def topics(self) -> AbstractSet[str]:
+        ...

--- a/src/roswire/common/state.py
+++ b/src/roswire/common/state.py
@@ -6,6 +6,24 @@ from typing import AbstractSet, Collection, Mapping
 
 
 class SystemState(ABC):
+    """
+    Provides a description of the instantaneous state of a ROS system in
+    terms of its publishers, subscribers, and services.
+
+    Attributes
+    ----------
+    publishers: Mapping[str, Collection[str]]
+        A mapping from topics to the names of publishers to that topic.
+    subscribers: Mapping[str, Collection[str]]
+        A mapping from topics to the names of subscribers to that topic.
+    services: Mapping[str, Collection[str]]
+        A mapping from services to the names of providers of that service.
+    nodes: AbstractSet[str]
+        The names of all known nodes running on the system.
+    topics: AbstractSet[str]
+        The names of all known topics on the system with at least one
+        publisher or one subscriber.
+    """
 
     @property
     @abstractmethod

--- a/src/roswire/ros1/state.py
+++ b/src/roswire/ros1/state.py
@@ -2,12 +2,52 @@
 __all__ = ("SystemStateProbe",)
 
 import xmlrpc
-from typing import Dict, Sequence, Tuple
+from typing import AbstractSet, Collection, Dict, Mapping, Sequence, Set, Tuple
 
 import attr
 
 from .. import exceptions as exc
 from ..common import SystemState
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class ROS1SystemState(SystemState):
+    """Provides a description of the instantaneous state of a ROS system in
+    terms of its publishers, subscribers, and services.
+
+    Attributes
+    ----------
+    publishers: Mapping[str, Collection[str]]
+        A mapping from topics to the names of publishers to that topic.
+    subscribers: Mapping[str, Collection[str]]
+        A mapping from topics to the names of subscribers to that topic.
+    services: Mapping[str, Collection[str]]
+        A mapping from services to the names of providers of that service.
+    nodes: AbstractSet[str]
+        The names of all known nodes running on the system.
+    topics: AbstractSet[str]
+        The names of all known topics on the system with at least one
+        publisher or one subscriber.
+    """
+
+    publishers: Mapping[str, Collection[str]]
+    subscribers: Mapping[str, Collection[str]]
+    services: Mapping[str, Collection[str]]
+    nodes: AbstractSet[str] = attr.ib(init=False, repr=False)
+    topics: AbstractSet[str] = attr.ib(init=False, repr=False)
+
+    def __attrs_post_init__(self) -> None:
+        nodes: Set[str] = set()
+        nodes = nodes.union(*self.publishers.values())
+        nodes = nodes.union(*self.subscribers.values())
+        nodes = nodes.union(*self.services.values())
+
+        topics: Set[str] = set()
+        topics = topics.union(self.publishers)
+        topics = topics.union(self.subscribers)
+
+        object.__setattr__(self, "nodes", frozenset(nodes))
+        object.__setattr__(self, "topics", frozenset(topics))
 
 
 @attr.s(frozen=True, auto_attribs=True)
@@ -21,7 +61,7 @@ class SystemStateProbe:
 
     @classmethod
     def via_xmlrpc_connection(
-        cls, connection: xmlrpc.client.ServerProxy
+            cls, connection: xmlrpc.client.ServerProxy
     ) -> "SystemStateProbe":
         return SystemStateProbe(connection)
 
@@ -52,7 +92,7 @@ class SystemStateProbe:
         for topic, service_names in result[2]:
             services[topic] = service_names
 
-        state = SystemState(
+        state = ROS1SystemState(
             publishers=publishers, subscribers=subscribers, services=services
         )
         return state

--- a/src/roswire/ros1/state.py
+++ b/src/roswire/ros1/state.py
@@ -12,23 +12,6 @@ from ..common import SystemState
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
 class ROS1SystemState(SystemState):
-    """Provides a description of the instantaneous state of a ROS system in
-    terms of its publishers, subscribers, and services.
-
-    Attributes
-    ----------
-    publishers: Mapping[str, Collection[str]]
-        A mapping from topics to the names of publishers to that topic.
-    subscribers: Mapping[str, Collection[str]]
-        A mapping from topics to the names of subscribers to that topic.
-    services: Mapping[str, Collection[str]]
-        A mapping from services to the names of providers of that service.
-    nodes: AbstractSet[str]
-        The names of all known nodes running on the system.
-    topics: AbstractSet[str]
-        The names of all known topics on the system with at least one
-        publisher or one subscriber.
-    """
 
     publishers: Mapping[str, Collection[str]]
     subscribers: Mapping[str, Collection[str]]
@@ -61,7 +44,7 @@ class SystemStateProbe:
 
     @classmethod
     def via_xmlrpc_connection(
-            cls, connection: xmlrpc.client.ServerProxy
+        cls, connection: xmlrpc.client.ServerProxy
     ) -> "SystemStateProbe":
         return SystemStateProbe(connection)
 

--- a/src/roswire/ros2/state.py
+++ b/src/roswire/ros2/state.py
@@ -2,7 +2,7 @@
 __all__ = ("ROS2StateProbe",)
 
 import typing
-from typing import Dict, Optional, Set
+from typing import AbstractSet, Collection, Dict, Mapping, Optional, Set
 
 import attr
 import dockerblade
@@ -12,6 +12,47 @@ from ..common import SystemState
 
 if typing.TYPE_CHECKING:
     from .. import AppInstance
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class ROS2SystemState(SystemState):
+    """
+    Provides a description of the instantaneous state of a ROS2 system in
+    terms of its publishers, subscribers, and services.
+
+    Attributes
+    ----------
+    publishers: Mapping[str, Collection[str]]
+        A mapping from topics to the names of publishers to that topic.
+    subscribers: Mapping[str, Collection[str]]
+        A mapping from topics to the names of subscribers to that topic.
+    services: Mapping[str, Collection[str]]
+        A mapping from services to the names of providers of that service.
+    nodes: AbstractSet[str]
+        The names of all known nodes running on the system.
+    topics: AbstractSet[str]
+        The names of all known topics on the system with at least one
+        publisher or one subscriber.
+    """
+
+    publishers: Mapping[str, Collection[str]]
+    subscribers: Mapping[str, Collection[str]]
+    services: Mapping[str, Collection[str]]
+    nodes: AbstractSet[str] = attr.ib(init=False, repr=False)
+    topics: AbstractSet[str] = attr.ib(init=False, repr=False)
+
+    def __attrs_post_init__(self) -> None:
+        nodes: Set[str] = set()
+        nodes = nodes.union(*self.publishers.values())
+        nodes = nodes.union(*self.subscribers.values())
+        nodes = nodes.union(*self.services.values())
+
+        topics: Set[str] = set()
+        topics = topics.union(self.publishers)
+        topics = topics.union(self.subscribers)
+
+        object.__setattr__(self, "nodes", frozenset(nodes))
+        object.__setattr__(self, "topics", frozenset(topics))
 
 
 @attr.s(frozen=True, auto_attribs=True)
@@ -27,7 +68,7 @@ class ROS2StateProbe:
     def for_app_instance(cls, app_instance: "AppInstance") -> "ROS2StateProbe":
         return ROS2StateProbe(app_instance=app_instance)
 
-    def probe(self) -> SystemState:
+    def probe(self) -> ROS2SystemState:
         """Obtains the instantaneous state of the associated ROS system."""
         shell = self._app_instance.shell
         node_to_state: Dict[Optional[str], Dict[str, Set[str]]] = {
@@ -75,7 +116,7 @@ class ROS2StateProbe:
                     else:
                         node_to_state[mode][name] = {node_name}
 
-        state = SystemState(
+        state = ROS2SystemState(
             publishers=node_to_state["pub"],
             subscribers=node_to_state["sub"],
             services=node_to_state["serv"],


### PR DESCRIPTION
The system state in ROS2 is more complete that ROS1, having actions and service clients recoverable as part of the node info. This pull request sets the refactoring of the SystemState into a version for ROS1 and ROS2.