### PR TITLE
Add topic, service, and action type information to ROS2State

### DIFF
--- a/src/roswire/exceptions.py
+++ b/src/roswire/exceptions.py
@@ -159,6 +159,18 @@ class ParsingError(ROSWireException):
 
 
 @_attr.s(frozen=True, auto_exc=True, auto_attribs=True, str=False)
+class ConflictingTypes(ROSWireException):
+    """ROSWire found two or more types for a service, topic, or action """
+
+    entity: str
+    existing: str
+    conflicting: str
+
+    def __str__(self) -> str:
+        return f"error declaring type {self.conflicting} for {self.entity}. It already has " \
+               f"type {self.existing}"
+
+@_attr.s(frozen=True, auto_exc=True, auto_attribs=True, str=False)
 class NoDescriptionError(RuntimeError, ROSWireException):
     """No description has been generated for an application."""
 

--- a/src/roswire/exceptions.py
+++ b/src/roswire/exceptions.py
@@ -167,8 +167,8 @@ class ConflictingTypes(ROSWireException):
     conflicting: str
 
     def __str__(self) -> str:
-        return f"error declaring type {self.conflicting} for {self.entity}. " \
-               f"It already has type {self.existing}"
+        return (f"error declaring type {self.conflicting} for {self.entity}. "
+                f"It already has type {self.existing}")
 
 
 @_attr.s(frozen=True, auto_exc=True, auto_attribs=True, str=False)

--- a/src/roswire/exceptions.py
+++ b/src/roswire/exceptions.py
@@ -160,15 +160,16 @@ class ParsingError(ROSWireException):
 
 @_attr.s(frozen=True, auto_exc=True, auto_attribs=True, str=False)
 class ConflictingTypes(ROSWireException):
-    """ROSWire found two or more types for a service, topic, or action """
+    """ROSWire found two or more types for a service, topic, or action."""
 
     entity: str
     existing: str
     conflicting: str
 
     def __str__(self) -> str:
-        return f"error declaring type {self.conflicting} for {self.entity}. It already has " \
-               f"type {self.existing}"
+        return f"error declaring type {self.conflicting} for {self.entity}. " \
+               f"It already has type {self.existing}"
+
 
 @_attr.s(frozen=True, auto_exc=True, auto_attribs=True, str=False)
 class NoDescriptionError(RuntimeError, ROSWireException):

--- a/src/roswire/ros2/ros2.py
+++ b/src/roswire/ros2/ros2.py
@@ -8,7 +8,8 @@ import attr
 from .launch import ROS2LaunchManager
 from .node_manager import ROS2NodeManager
 from .service_manager import ROS2ServiceManager
-from .state import ROS2StateProbe, ROS2SystemState
+from .state import ROS2StateProbe
+from ..common import SystemState
 
 if typing.TYPE_CHECKING:
     from .. import AppInstance
@@ -39,5 +40,5 @@ class ROS2:
         return ROS2(app_instance=app_instance)
 
     @property
-    def state(self) -> ROS2SystemState:
+    def state(self) -> SystemState:
         return self._state_probe.probe()

--- a/src/roswire/ros2/ros2.py
+++ b/src/roswire/ros2/ros2.py
@@ -8,8 +8,7 @@ import attr
 from .launch import ROS2LaunchManager
 from .node_manager import ROS2NodeManager
 from .service_manager import ROS2ServiceManager
-from .state import ROS2StateProbe
-from ..common import SystemState
+from .state import ROS2StateProbe, ROS2SystemState
 
 if typing.TYPE_CHECKING:
     from .. import AppInstance
@@ -40,5 +39,5 @@ class ROS2:
         return ROS2(app_instance=app_instance)
 
     @property
-    def state(self) -> SystemState:
+    def state(self) -> ROS2SystemState:
         return self._state_probe.probe()

--- a/src/roswire/ros2/state.py
+++ b/src/roswire/ros2/state.py
@@ -42,11 +42,11 @@ class ROS2SystemState(SystemState):
     action_clients: Mapping[str, Collection[str]]
         A mapping from actions to the names of clients of that action
     topic_to_type: Mapping[str, str]
-        A mapping from topics to their type
+        A mapping from topics to the name of their type
     service_to_type: Mapping[str, str]
-        A mapping from services to their type
-    action_to_type:
-        A mapping from actions to their type
+        A mapping from services to the name of their type
+    action_to_type: Mapping[str, str]
+        A mapping from actions to the name of their type
     nodes: AbstractSet[str]
         The names of all known nodes running on the system.
     topics: AbstractSet[str]
@@ -125,7 +125,7 @@ class ROS2StateProbe:
             _ACTION_SERVERS: {},
             _ACTION_CLIENTS: {}
         }
-        # The place to store type information
+
         topic_to_type: Dict[str, str] = {}
         service_to_type: Dict[str, str] = {}
         action_to_type: Dict[str, str] = {}
@@ -190,7 +190,7 @@ class ROS2StateProbe:
                     # should never happen)
                     if name in types and fmt != types[name]:
                         logger.warning(
-                            f'The entity {name} has conflictig types: '
+                            f'The entity {name} has conflicting types: '
                             f'{types[name]} =/= {fmt}')
                     else:
                         types[name] = fmt

--- a/src/roswire/ros2/state.py
+++ b/src/roswire/ros2/state.py
@@ -199,7 +199,9 @@ class ROS2StateProbe:
                         logger.error(
                             f'The entity {name} has conflicting types: '
                             f'{types[name]} =/= {fmt}')
-                        raise ConflictingTypes(entity=name, existing=types[name], conflicting=fmt)
+                        raise ConflictingTypes(entity=name,
+                                               existing=types[name],
+                                               conflicting=fmt)
                     else:
                         types[name] = fmt
 

--- a/src/roswire/ros2/state.py
+++ b/src/roswire/ros2/state.py
@@ -180,17 +180,19 @@ class ROS2StateProbe:
                 if mode:
                     partition = line.partition(":")
                     name = partition[0]
-                    type_ = partition[1]
+                    fmt = partition[1]
                     if name in node_to_state[mode]:
                         node_to_state[mode][name].add(node_name)
                     else:
                         node_to_state[mode][name] = {node_name}
-                    if name in types and type_ != types[name]:
+                    # Add type information and report conflict if a different types
+                    # was registered (probably should never happen)
+                    if name in types and fmt != types[name]:
                         logger.warning(
                             f'The entity {name} has conflictig types: '
-                            f'{types[name]} =/= {type_}')
+                            f'{types[name]} =/= {fmt}')
                     else:
-                        types[name] = type_
+                        types[name] = fmt
 
         state = ROS2SystemState(
             publishers=node_to_state[_PUBLISHERS],

--- a/src/roswire/ros2/state.py
+++ b/src/roswire/ros2/state.py
@@ -18,7 +18,7 @@ if typing.TYPE_CHECKING:
 class ROS2SystemState(SystemState):
     """
     Provides a description of the instantaneous state of a ROS2 system in
-    terms of its publishers, subscribers, and services.
+    terms of its publishers, subscribers, actions, and services.
 
     Attributes
     ----------

--- a/src/roswire/ros2/state.py
+++ b/src/roswire/ros2/state.py
@@ -185,8 +185,9 @@ class ROS2StateProbe:
                         node_to_state[mode][name].add(node_name)
                     else:
                         node_to_state[mode][name] = {node_name}
-                    # Add type information and report conflict if a different types
-                    # was registered (probably should never happen)
+                    # Add type information and report conflict if a
+                    # different types was registered (probably
+                    # should never happen)
                     if name in types and fmt != types[name]:
                         logger.warning(
                             f'The entity {name} has conflictig types: '

--- a/src/roswire/ros2/state.py
+++ b/src/roswire/ros2/state.py
@@ -10,12 +10,12 @@ from loguru import logger
 
 from ..common import SystemState
 
-ACTION_CLIENTS = "act_cli"
-ACTION_SERVERS = "act_serv"
-SERVICE_CLIENTS = "cli"
-SERVICES = "serv"
-SUBSCRIBERS = "sub"
-PUBLISHERS = "pub"
+_ACTION_CLIENTS = "act_cli"
+_ACTION_SERVERS = "act_serv"
+_SERVICE_CLIENTS = "cli"
+_SERVICES = "serv"
+_SUBSCRIBERS = "sub"
+_PUBLISHERS = "pub"
 
 if typing.TYPE_CHECKING:
     from .. import AppInstance
@@ -84,16 +84,16 @@ class ROS2SystemState(SystemState):
         nodes = nodes.union(*self.action_clients.values())
 
         topics: Set[str] = set()
-        topics = topics.union(self.publishers)
-        topics = topics.union(self.subscribers)
+        topics = topics.union(self.publishers.keys())
+        topics = topics.union(self.subscribers.keys())
 
         service_names: Set[str] = set()
-        service_names = service_names.union(self.services)
-        service_names = service_names.union(self.service_clients)
+        service_names = service_names.union(self.services.keys())
+        service_names = service_names.union(self.service_clients.keys())
 
         action_names: Set[str] = set()
-        action_names = action_names.union(self.action_servers)
-        action_names = action_names.union(self.action_clients)
+        action_names = action_names.union(self.action_servers.keys())
+        action_names = action_names.union(self.action_clients.keys())
 
         object.__setattr__(self, "nodes", frozenset(nodes))
         object.__setattr__(self, "topics", frozenset(topics))
@@ -118,12 +118,12 @@ class ROS2StateProbe:
         """Obtains the instantaneous state of the associated ROS system."""
         shell = self._app_instance.shell
         node_to_state: Dict[Optional[str], Dict[str, Set[str]]] = {
-            PUBLISHERS: {},
-            SUBSCRIBERS: {},
-            SERVICES: {},
-            SERVICE_CLIENTS: {},
-            ACTION_SERVERS: {},
-            ACTION_CLIENTS: {}
+            _PUBLISHERS: {},
+            _SUBSCRIBERS: {},
+            _SERVICES: {},
+            _SERVICE_CLIENTS: {},
+            _ACTION_SERVERS: {},
+            _ACTION_CLIENTS: {}
         }
         # The place to store type information
         topic_to_type: Dict[str, str] = {}
@@ -153,27 +153,27 @@ class ROS2StateProbe:
             lines = output.split("\r\n")
             for line in lines:
                 if "Publishers:" in line:
-                    mode = PUBLISHERS
+                    mode = _PUBLISHERS
                     types = topic_to_type
                     continue
                 elif "Subscribers:" in line:
-                    mode = SUBSCRIBERS
+                    mode = _SUBSCRIBERS
                     types = topic_to_type
                     continue
                 elif "Services:" in line:
-                    mode = SERVICES
+                    mode = _SERVICES
                     types = service_to_type
                     continue
                 elif "Action Servers:" in line:
-                    mode = ACTION_SERVERS
+                    mode = _ACTION_SERVERS
                     types = action_to_type
                     continue
                 elif "Service Clients:" in line:
-                    mode = SERVICE_CLIENTS
+                    mode = _SERVICE_CLIENTS
                     types = service_to_type
                     continue
                 elif "Action Clients:" in line:
-                    mode = ACTION_CLIENTS
+                    mode = _ACTION_CLIENTS
                     types = action_to_type
                     continue
 
@@ -193,12 +193,12 @@ class ROS2StateProbe:
                         types[name] = type_
 
         state = ROS2SystemState(
-            publishers=node_to_state[PUBLISHERS],
-            subscribers=node_to_state[SUBSCRIBERS],
-            services=node_to_state[SERVICES],
-            service_clients=node_to_state[SERVICE_CLIENTS],
-            action_servers=node_to_state[ACTION_SERVERS],
-            action_clients=node_to_state[ACTION_CLIENTS],
+            publishers=node_to_state[_PUBLISHERS],
+            subscribers=node_to_state[_SUBSCRIBERS],
+            services=node_to_state[_SERVICES],
+            service_clients=node_to_state[_SERVICE_CLIENTS],
+            action_servers=node_to_state[_ACTION_SERVERS],
+            action_clients=node_to_state[_ACTION_CLIENTS],
             topic_to_type=topic_to_type,
             service_to_type=service_to_type,
             action_to_type=action_to_type

--- a/src/roswire/ros2/state.py
+++ b/src/roswire/ros2/state.py
@@ -121,7 +121,8 @@ class ROS2StateProbe:
         Raises
         ------
         ConflictingTypeException
-            If more than one type is detected for topics, services, or actions
+            If more than one type is detected for a given topic, service,
+            or action
         """
         shell = self._app_instance.shell
         node_to_state: Dict[Optional[str], Dict[str, Set[str]]] = {


### PR DESCRIPTION
The type information in ROS2 can be gleaned from ros2 info, and so we will cache it in the state.