### PR TITLE
Refactor pattern matching in Msgs into constituent parts

### DIFF
--- a/src/roswire/common/msg.py
+++ b/src/roswire/common/msg.py
@@ -58,15 +58,13 @@ class Constant:
     value: Union[str, int, float]
 
     @classmethod
-    def from_string(cls, package: str, line: str) -> "Optional[Constant]":
+    def from_string(cls, line: str) -> "Optional[Constant]":
         """
         Produce a constant from a string, checking first if it is a valid
         constant, otherwise None.
 
         Parameters
         ----------
-        package: str
-            The name of the package that provides the constant.
         line: str
             The line of text containing the constant.
 
@@ -302,7 +300,7 @@ class MsgFormat:
             if m_blank:
                 continue
 
-            constant = Constant.from_string(package, line)
+            constant = Constant.from_string(line)
             field = Field.from_string(package, line)
             if constant:
                 constants.append(constant)

--- a/src/roswire/common/msg.py
+++ b/src/roswire/common/msg.py
@@ -118,7 +118,7 @@ class Field:
     name: str
 
     @classmethod
-    def from_string(cls, package: str,  line: str) -> "Optional[Field]":
+    def from_string(cls, package: str, line: str) -> "Optional[Field]":
         """
 
         Parameters
@@ -151,6 +151,8 @@ class Field:
                 typ = typ_resolved
 
             field: Field = Field(typ, name_field)
+            return field
+        return None
 
     @property
     def is_array(self) -> bool:
@@ -297,8 +299,8 @@ class MsgFormat:
             if m_blank:
                 continue
 
-            constant = Constant.from_string(package, name, line)
-            field = Field.from_string(package, name, line)
+            constant = Constant.from_string(package, line)
+            field = Field.from_string(package, line)
             if constant:
                 constants.append(constant)
             elif field:

--- a/src/roswire/common/msg.py
+++ b/src/roswire/common/msg.py
@@ -60,7 +60,8 @@ class Constant:
     @classmethod
     def from_string(cls, package: str, line: str) -> "Optional[Constant]":
         """
-        Produce a constant from a string, checking first if it is a valid constant, otherwise None.
+        Produce a constant from a string, checking first if it is a valid
+        constant, otherwise None.
 
         Parameters
         ----------
@@ -120,7 +121,8 @@ class Field:
     @classmethod
     def from_string(cls, package: str, line: str) -> "Optional[Field]":
         """
-        Produce a field from a string, checking first if it is a valid field, otherwise None.
+        Produce a field from a string, checking first if it is a
+        valid field, otherwise None.
 
         Parameters
         ----------

--- a/src/roswire/common/msg.py
+++ b/src/roswire/common/msg.py
@@ -60,18 +60,19 @@ class Constant:
     @classmethod
     def from_string(cls, package: str, line: str) -> "Optional[Constant]":
         """
+        Produce a constant from a string, checking first if it is a valid constant, otherwise None.
 
         Parameters
         ----------
         package: str
             The name of the package that provides the constant.
         line: str
-            The line of text containing the constant
+            The line of text containing the constant.
 
         Returns
         -------
         Optional[Constant]
-            A Constant object if the line is a constant, None otherwise
+            A Constant object if the line is a constant, None otherwise.
         """
         m_string_constant = cls.R_STRING_CONSTANT.match(line)
         m_other_constant = cls.R_OTHER_CONSTANT.match(line)
@@ -111,7 +112,6 @@ class Field:
 
     R_TYPE = r"[a-zA-Z0-9_/]+(?:\[(?:<=)?\d*\])?"
     R_NAME = r"[a-zA-Z0-9_/]+"
-    R_VAL = r".+"
     R_FIELD = re.compile(f"^\s*({R_TYPE})\s+({R_NAME})\s*{R_COMMENT}$")
 
     typ: str
@@ -120,18 +120,19 @@ class Field:
     @classmethod
     def from_string(cls, package: str, line: str) -> "Optional[Field]":
         """
+        Produce a field from a string, checking first if it is a valid field, otherwise None.
 
         Parameters
         ----------
         package: str
             The name of the package that provides the field.
         line: str
-            The line of text containing the field
+            The line of text containing the field.
 
         Returns
         -------
         Optional[Field]
-            A Field object if the line is a constant, None otherwise
+            A Field object if the line is a constant, None otherwise.
         """
         m_field = cls.R_FIELD.match(line)
 


### PR DESCRIPTION
Move the regular expression matching into Constant and Field. This will help down the line with constructing ROS2Field with different pattern for default and bounded.

(This is related to issue #420)