### PR TITLE
Refactor FormatDatabase into ROS1 and ROS2 versions

### DIFF
--- a/src/roswire/app/description.py
+++ b/src/roswire/app/description.py
@@ -56,10 +56,10 @@ class AppDescription:
         formats: FormatDatabase
         if distribution.ros == ROSVersion.ROS1:
             packages = ROS1PackageDatabase.from_dict(d["packages"])
-            formats = ROS1FormatDatabase.build(packages)
+            formats = ROS1FormatDatabase.from_packages(packages)
         else:
             packages = ROS2PackageDatabase.from_dict(d["packages"])
-            formats = ROS2FormatDatabase.build(packages)
+            formats = ROS2FormatDatabase.from_packages(packages)
         types = TypeDatabase.build(formats)
         return AppDescription(
             app=app,
@@ -131,10 +131,10 @@ class AppDescription:
             db_format: FormatDatabase
             if distribution.ros == ROSVersion.ROS1:
                 db_package = ROS1PackageDatabase.build(app_instance)
-                db_format = ROS1FormatDatabase.build(db_package)
+                db_format = ROS1FormatDatabase.from_packages(db_package)
             else:
                 db_package = ROS2PackageDatabase.build(app_instance)
-                db_format = ROS2FormatDatabase.build(db_package)
+                db_format = ROS2FormatDatabase.from_packages(db_package)
         db_type = TypeDatabase.build(db_format)
         return AppDescription(
             app=app,

--- a/src/roswire/app/description.py
+++ b/src/roswire/app/description.py
@@ -13,8 +13,8 @@ from loguru import logger
 
 from ..common import FormatDatabase, PackageDatabase, TypeDatabase
 from ..distribution import ROSDistribution, ROSVersion
-from ..ros1 import ROS1PackageDatabase
-from ..ros2 import ROS2PackageDatabase
+from ..ros1 import ROS1FormatDatabase, ROS1PackageDatabase
+from ..ros2 import ROS2FormatDatabase, ROS2PackageDatabase
 
 if typing.TYPE_CHECKING:
     from .app import App
@@ -53,11 +53,13 @@ class AppDescription:
     ) -> "AppDescription":
         distribution = ROSDistribution.with_name(d["distribution"])
         packages: PackageDatabase
+        formats: FormatDatabase
         if distribution.ros == ROSVersion.ROS1:
             packages = ROS1PackageDatabase.from_dict(d["packages"])
+            formats = ROS1FormatDatabase.build(packages)
         else:
             packages = ROS2PackageDatabase.from_dict(d["packages"])
-        formats = FormatDatabase.build(packages)
+            formats = ROS2FormatDatabase.build(packages)
         types = TypeDatabase.build(formats)
         return AppDescription(
             app=app,
@@ -126,11 +128,13 @@ class AppDescription:
             distribution_name = app_instance.shell.environ("ROS_DISTRO")
             distribution = ROSDistribution.with_name(distribution_name)
             db_package: PackageDatabase
+            db_format: FormatDatabase
             if distribution.ros == ROSVersion.ROS1:
                 db_package = ROS1PackageDatabase.build(app_instance)
+                db_format = ROS1FormatDatabase.build(db_package)
             else:
                 db_package = ROS2PackageDatabase.build(app_instance)
-        db_format = FormatDatabase.build(db_package)
+                db_format = ROS2FormatDatabase.build(db_package)
         db_type = TypeDatabase.build(db_format)
         return AppDescription(
             app=app,

--- a/src/roswire/common/format.py
+++ b/src/roswire/common/format.py
@@ -65,15 +65,6 @@ class FormatDatabase(ABC, Generic[MF, SF, AF]):
 
         return cls(messages, services, actions)
 
-    @classmethod
-    @abstractmethod
-    def build(cls,
-              messages: Set[MF],
-              services: Set[SF],
-              actions: Set[AF]
-              ) -> "FormatDatabase":
-        ...
-
     def __init__(
             self,
             messages: Set[MF],
@@ -116,6 +107,7 @@ class FormatDatabase(ABC, Generic[MF, SF, AF]):
             yaml.dump(self.to_dict(), f, default_flow_style=False)
 
     @classmethod
+    @abstractmethod
     def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
         """Loads a format database from a JSON document."""
         ...

--- a/src/roswire/common/format.py
+++ b/src/roswire/common/format.py
@@ -66,10 +66,10 @@ class FormatDatabase(ABC, Generic[MF, SF, AF]):
         return cls(messages, services, actions)
 
     def __init__(
-            self,
-            messages: Set[MF],
-            services: Set[SF],
-            actions: Set[AF],
+        self,
+        messages: Set[MF],
+        services: Set[SF],
+        actions: Set[AF],
     ) -> None:
         self.__messages: Mapping[str, MF] = MappingProxyType(
             {f.fullname: f for f in messages}

--- a/src/roswire/common/format.py
+++ b/src/roswire/common/format.py
@@ -38,6 +38,7 @@ class FormatDatabase(ABC, Generic[MF, SF, AF]):
     @classmethod
     @abstractmethod
     def build(cls, db: PackageDatabase) -> "FormatDatabase":
+        """Constructs a format database from a given package database."""
         ...
 
     @property
@@ -70,8 +71,10 @@ class FormatDatabase(ABC, Generic[MF, SF, AF]):
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
+        """Loads a format database from a JSON document."""
         ...
 
     @classmethod
     def load(cls, fn: str) -> "FormatDatabase":
+        """Loads a format database from a given file on disk."""
         ...

--- a/src/roswire/common/format.py
+++ b/src/roswire/common/format.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 __all__ = ("FormatDatabase",)
 
-from types import MappingProxyType
-from typing import Any, Dict, Mapping, Set
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Generic, Mapping, TypeVar
 
 import yaml
 
@@ -12,7 +12,12 @@ from .package import PackageDatabase
 from .srv import SrvFormat
 
 
-class FormatDatabase:
+MF = TypeVar("MF", bound=MsgFormat)
+SF = TypeVar("SF", bound=SrvFormat)
+AF = TypeVar("AF", bound=ActionFormat)
+
+
+class FormatDatabase(ABC, Generic[MF, SF, AF]):
     """
     An immutable database of ROS definitions that maintains the parsed
     contents of :code:`.msg`, :code:`.srv`, and :code:`.action` files
@@ -30,77 +35,33 @@ class FormatDatabase:
         An immutable mapping from action name to definition.
     """
 
-    @staticmethod
-    def build(db: PackageDatabase) -> "FormatDatabase":
-        """Constructs a format database from a given package database."""
-        messages: Set[MsgFormat] = set()
-        services: Set[SrvFormat] = set()
-        actions: Set[ActionFormat] = set()
-
-        for package in db.values():
-            messages.update(package.messages)
-            services.update(package.services)
-            actions.update(package.actions)
-
-            for service in package.services:
-                if service.request:
-                    messages.add(service.request)
-                if service.response:
-                    messages.add(service.response)
-
-            for action in package.actions:
-                if action.goal:
-                    messages.add(action.goal)
-                if action.result:
-                    messages.add(action.result)
-                if action.feedback:
-                    messages.add(action.feedback)
-
-        return FormatDatabase(messages, services, actions)
-
-    def __init__(
-        self,
-        messages: Set[MsgFormat],
-        services: Set[SrvFormat],
-        actions: Set[ActionFormat],
-    ) -> None:
-        self.__messages: Mapping[str, MsgFormat] = MappingProxyType(
-            {f.fullname: f for f in messages}
-        )
-        self.__services: Mapping[str, SrvFormat] = MappingProxyType(
-            {f.fullname: f for f in services}
-        )
-        self.__actions: Mapping[str, ActionFormat] = MappingProxyType(
-            {f.fullname: f for f in actions}
-        )
+    @classmethod
+    @abstractmethod
+    def build(cls, db: PackageDatabase) -> "FormatDatabase":
+        ...
 
     @property
-    def messages(self) -> Mapping[str, MsgFormat]:
-        return self.__messages
+    @abstractmethod
+    def messages(self) -> Mapping[str, MF]:
+        ...
 
     @property
-    def services(self) -> Mapping[str, SrvFormat]:
-        return self.__services
+    @abstractmethod
+    def services(self) -> Mapping[str, SF]:
+        ...
 
     @property
-    def actions(self) -> Mapping[str, ActionFormat]:
-        return self.__actions
+    @abstractmethod
+    def actions(self) -> Mapping[str, AF]:
+        ...
 
     def to_dict(self) -> Dict[str, Any]:
         """Returns a JSON description of this database."""
         return {
-            "messages": [m.to_dict() for m in self.__messages.values()],
-            "services": [s.to_dict() for s in self.__services.values()],
-            "actions": [a.to_dict() for a in self.__actions.values()],
+            "messages": [m.to_dict() for m in self.messages.values()],
+            "services": [s.to_dict() for s in self.services.values()],
+            "actions": [a.to_dict() for a in self.actions.values()],
         }
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
-        """Loads a format database from a JSON document."""
-        msg = {MsgFormat.from_dict(dd) for dd in d["messages"]}
-        srv = {SrvFormat.from_dict(dd) for dd in d["services"]}
-        action = {ActionFormat.from_dict(dd) for dd in d["actions"]}
-        return FormatDatabase(msg, srv, action)
 
     def save(self, fn: str) -> None:
         """Saves the contents of this format database to disk."""
@@ -108,7 +69,9 @@ class FormatDatabase:
             yaml.dump(self.to_dict(), f, default_flow_style=False)
 
     @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
+        ...
+
+    @classmethod
     def load(cls, fn: str) -> "FormatDatabase":
-        """Loads a format database from a given file on disk."""
-        with open(fn, "r") as f:
-            return cls.from_dict(yaml.safe_load(f))
+        ...

--- a/src/roswire/ros1/__init__.py
+++ b/src/roswire/ros1/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from .format import ROS1FormatDatabase
 from .launch import ROS1LaunchManager
 from .node import ROS1Node
 from .node_manager import ROS1NodeManager

--- a/src/roswire/ros1/format.py
+++ b/src/roswire/ros1/format.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 __all__ = ("ROS1FormatDatabase",)
 
-from types import MappingProxyType
-from typing import Any, Dict, Mapping, Set
-
-import yaml
+from typing import Any, Dict, Set
 
 from ..common import (
     ActionFormat,
     FormatDatabase,
     MsgFormat,
-    PackageDatabase,
     SrvFormat,
 )
 
@@ -18,60 +14,12 @@ from ..common import (
 class ROS1FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ActionFormat]):
 
     @classmethod
-    def build(cls, db: PackageDatabase) -> "ROS1FormatDatabase":
-        """Constructs a format database from a given package database."""
-        messages: Set[MsgFormat] = set()
-        services: Set[SrvFormat] = set()
-        actions: Set[ActionFormat] = set()
-
-        for package in db.values():
-            messages.update(package.messages)
-            services.update(package.services)
-            actions.update(package.actions)
-
-            for service in package.services:
-                if service.request:
-                    messages.add(service.request)
-                if service.response:
-                    messages.add(service.response)
-
-            for action in package.actions:
-                if action.goal:
-                    messages.add(action.goal)
-                if action.result:
-                    messages.add(action.result)
-                if action.feedback:
-                    messages.add(action.feedback)
-
+    def build(cls,
+              messages: Set[MsgFormat],
+              services: Set[SrvFormat],
+              actions: Set[ActionFormat]
+              ) -> "FormatDatabase":
         return ROS1FormatDatabase(messages, services, actions)
-
-    def __init__(
-        self,
-        messages: Set[MsgFormat],
-        services: Set[SrvFormat],
-        actions: Set[ActionFormat],
-    ) -> None:
-        self.__messages: Mapping[str, MsgFormat] = MappingProxyType(
-            {f.fullname: f for f in messages}
-        )
-        self.__services: Mapping[str, SrvFormat] = MappingProxyType(
-            {f.fullname: f for f in services}
-        )
-        self.__actions: Mapping[str, ActionFormat] = MappingProxyType(
-            {f.fullname: f for f in actions}
-        )
-
-    @property
-    def messages(self) -> Mapping[str, MsgFormat]:
-        return self.__messages
-
-    @property
-    def services(self) -> Mapping[str, SrvFormat]:
-        return self.__services
-
-    @property
-    def actions(self) -> Mapping[str, ActionFormat]:
-        return self.__actions
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
@@ -79,10 +27,4 @@ class ROS1FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ActionFormat]):
         msg = {MsgFormat.from_dict(dd) for dd in d["messages"]}
         srv = {SrvFormat.from_dict(dd) for dd in d["services"]}
         action = {ActionFormat.from_dict(dd) for dd in d["actions"]}
-        return ROS1FormatDatabase(msg, srv, action)
-
-    @classmethod
-    def load(cls, fn: str) -> "FormatDatabase":
-        """Loads a format database from a given file on disk."""
-        with open(fn, "r") as f:
-            return cls.from_dict(yaml.safe_load(f))
+        return cls.build(msg, srv, action)

--- a/src/roswire/ros1/format.py
+++ b/src/roswire/ros1/format.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+__all__ = ("ROS1FormatDatabase",)
+
+from types import MappingProxyType
+from typing import Any, Dict, Mapping, Set
+
+import yaml
+
+from ..common import (
+    ActionFormat,
+    FormatDatabase,
+    MsgFormat,
+    PackageDatabase,
+    SrvFormat,
+)
+
+
+class ROS1FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ActionFormat]):
+
+    @classmethod
+    def build(cls, db: PackageDatabase) -> "ROS1FormatDatabase":
+        """Constructs a format database from a given package database."""
+        messages: Set[MsgFormat] = set()
+        services: Set[SrvFormat] = set()
+        actions: Set[ActionFormat] = set()
+
+        for package in db.values():
+            messages.update(package.messages)
+            services.update(package.services)
+            actions.update(package.actions)
+
+            for service in package.services:
+                if service.request:
+                    messages.add(service.request)
+                if service.response:
+                    messages.add(service.response)
+
+            for action in package.actions:
+                if action.goal:
+                    messages.add(action.goal)
+                if action.result:
+                    messages.add(action.result)
+                if action.feedback:
+                    messages.add(action.feedback)
+
+        return ROS1FormatDatabase(messages, services, actions)
+
+    def __init__(
+        self,
+        messages: Set[MsgFormat],
+        services: Set[SrvFormat],
+        actions: Set[ActionFormat],
+    ) -> None:
+        self.__messages: Mapping[str, MsgFormat] = MappingProxyType(
+            {f.fullname: f for f in messages}
+        )
+        self.__services: Mapping[str, SrvFormat] = MappingProxyType(
+            {f.fullname: f for f in services}
+        )
+        self.__actions: Mapping[str, ActionFormat] = MappingProxyType(
+            {f.fullname: f for f in actions}
+        )
+
+    @property
+    def messages(self) -> Mapping[str, MsgFormat]:
+        return self.__messages
+
+    @property
+    def services(self) -> Mapping[str, SrvFormat]:
+        return self.__services
+
+    @property
+    def actions(self) -> Mapping[str, ActionFormat]:
+        return self.__actions
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
+        """Loads a format database from a JSON document."""
+        msg = {MsgFormat.from_dict(dd) for dd in d["messages"]}
+        srv = {SrvFormat.from_dict(dd) for dd in d["services"]}
+        action = {ActionFormat.from_dict(dd) for dd in d["actions"]}
+        return ROS1FormatDatabase(msg, srv, action)
+
+    @classmethod
+    def load(cls, fn: str) -> "FormatDatabase":
+        """Loads a format database from a given file on disk."""
+        with open(fn, "r") as f:
+            return cls.from_dict(yaml.safe_load(f))

--- a/src/roswire/ros1/format.py
+++ b/src/roswire/ros1/format.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 __all__ = ("ROS1FormatDatabase",)
 
-from typing import Any, Dict, Set
+from typing import Any, Dict
 
 from ..common import (
     ActionFormat,
@@ -14,17 +14,9 @@ from ..common import (
 class ROS1FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ActionFormat]):
 
     @classmethod
-    def build(cls,
-              messages: Set[MsgFormat],
-              services: Set[SrvFormat],
-              actions: Set[ActionFormat]
-              ) -> "FormatDatabase":
-        return ROS1FormatDatabase(messages, services, actions)
-
-    @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
         """Loads a format database from a JSON document."""
         msg = {MsgFormat.from_dict(dd) for dd in d["messages"]}
         srv = {SrvFormat.from_dict(dd) for dd in d["services"]}
         action = {ActionFormat.from_dict(dd) for dd in d["actions"]}
-        return cls.build(msg, srv, action)
+        return cls(msg, srv, action)

--- a/src/roswire/ros2/__init__.py
+++ b/src/roswire/ros2/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from .format import ROS2FormatDatabase
 from .launch import ROS2LaunchManager
 from .node_manager import ROS2NodeManager
 from .package import ROS2PackageDatabase

--- a/src/roswire/ros2/format.py
+++ b/src/roswire/ros2/format.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 __all__ = ("ROS2FormatDatabase",)
 
-from types import MappingProxyType
-from typing import Any, Dict, Mapping, Set
-
-import yaml
+from typing import Any, Dict, Set
 
 from ..common import (
     ActionFormat,
     FormatDatabase,
     MsgFormat,
-    PackageDatabase,
     SrvFormat,
 )
 
@@ -18,60 +14,12 @@ from ..common import (
 class ROS2FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ActionFormat]):
 
     @classmethod
-    def build(cls, db: PackageDatabase) -> "ROS2FormatDatabase":
-        """Constructs a format database from a given package database."""
-        messages: Set[MsgFormat] = set()
-        services: Set[SrvFormat] = set()
-        actions: Set[ActionFormat] = set()
-
-        for package in db.values():
-            messages.update(package.messages)
-            services.update(package.services)
-            actions.update(package.actions)
-
-            for service in package.services:
-                if service.request:
-                    messages.add(service.request)
-                if service.response:
-                    messages.add(service.response)
-
-            for action in package.actions:
-                if action.goal:
-                    messages.add(action.goal)
-                if action.result:
-                    messages.add(action.result)
-                if action.feedback:
-                    messages.add(action.feedback)
-
+    def build(cls,
+              messages: Set[MsgFormat],
+              services: Set[SrvFormat],
+              actions: Set[ActionFormat]
+              ) -> "FormatDatabase":
         return ROS2FormatDatabase(messages, services, actions)
-
-    def __init__(
-        self,
-        messages: Set[MsgFormat],
-        services: Set[SrvFormat],
-        actions: Set[ActionFormat],
-    ) -> None:
-        self.__messages: Mapping[str, MsgFormat] = MappingProxyType(
-            {f.fullname: f for f in messages}
-        )
-        self.__services: Mapping[str, SrvFormat] = MappingProxyType(
-            {f.fullname: f for f in services}
-        )
-        self.__actions: Mapping[str, ActionFormat] = MappingProxyType(
-            {f.fullname: f for f in actions}
-        )
-
-    @property
-    def messages(self) -> Mapping[str, MsgFormat]:
-        return self.__messages
-
-    @property
-    def services(self) -> Mapping[str, SrvFormat]:
-        return self.__services
-
-    @property
-    def actions(self) -> Mapping[str, ActionFormat]:
-        return self.__actions
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
@@ -80,9 +28,3 @@ class ROS2FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ActionFormat]):
         srv = {SrvFormat.from_dict(dd) for dd in d["services"]}
         action = {ActionFormat.from_dict(dd) for dd in d["actions"]}
         return ROS2FormatDatabase(msg, srv, action)
-
-    @classmethod
-    def load(cls, fn: str) -> "FormatDatabase":
-        """Loads a format database from a given file on disk."""
-        with open(fn, "r") as f:
-            return cls.from_dict(yaml.safe_load(f))

--- a/src/roswire/ros2/format.py
+++ b/src/roswire/ros2/format.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+__all__ = ("ROS2FormatDatabase",)
+
+from types import MappingProxyType
+from typing import Any, Dict, Mapping, Set
+
+import yaml
+
+from ..common import (
+    ActionFormat,
+    FormatDatabase,
+    MsgFormat,
+    PackageDatabase,
+    SrvFormat,
+)
+
+
+class ROS2FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ActionFormat]):
+
+    @classmethod
+    def build(cls, db: PackageDatabase) -> "ROS2FormatDatabase":
+        """Constructs a format database from a given package database."""
+        messages: Set[MsgFormat] = set()
+        services: Set[SrvFormat] = set()
+        actions: Set[ActionFormat] = set()
+
+        for package in db.values():
+            messages.update(package.messages)
+            services.update(package.services)
+            actions.update(package.actions)
+
+            for service in package.services:
+                if service.request:
+                    messages.add(service.request)
+                if service.response:
+                    messages.add(service.response)
+
+            for action in package.actions:
+                if action.goal:
+                    messages.add(action.goal)
+                if action.result:
+                    messages.add(action.result)
+                if action.feedback:
+                    messages.add(action.feedback)
+
+        return ROS2FormatDatabase(messages, services, actions)
+
+    def __init__(
+        self,
+        messages: Set[MsgFormat],
+        services: Set[SrvFormat],
+        actions: Set[ActionFormat],
+    ) -> None:
+        self.__messages: Mapping[str, MsgFormat] = MappingProxyType(
+            {f.fullname: f for f in messages}
+        )
+        self.__services: Mapping[str, SrvFormat] = MappingProxyType(
+            {f.fullname: f for f in services}
+        )
+        self.__actions: Mapping[str, ActionFormat] = MappingProxyType(
+            {f.fullname: f for f in actions}
+        )
+
+    @property
+    def messages(self) -> Mapping[str, MsgFormat]:
+        return self.__messages
+
+    @property
+    def services(self) -> Mapping[str, SrvFormat]:
+        return self.__services
+
+    @property
+    def actions(self) -> Mapping[str, ActionFormat]:
+        return self.__actions
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
+        """Loads a format database from a JSON document."""
+        msg = {MsgFormat.from_dict(dd) for dd in d["messages"]}
+        srv = {SrvFormat.from_dict(dd) for dd in d["services"]}
+        action = {ActionFormat.from_dict(dd) for dd in d["actions"]}
+        return ROS2FormatDatabase(msg, srv, action)
+
+    @classmethod
+    def load(cls, fn: str) -> "FormatDatabase":
+        """Loads a format database from a given file on disk."""
+        with open(fn, "r") as f:
+            return cls.from_dict(yaml.safe_load(f))

--- a/src/roswire/ros2/format.py
+++ b/src/roswire/ros2/format.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 __all__ = ("ROS2FormatDatabase",)
 
-from typing import Any, Dict, Set
+from typing import Any, Dict
 
 from ..common import (
     ActionFormat,
@@ -12,14 +12,6 @@ from ..common import (
 
 
 class ROS2FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ActionFormat]):
-
-    @classmethod
-    def build(cls,
-              messages: Set[MsgFormat],
-              services: Set[SrvFormat],
-              actions: Set[ActionFormat]
-              ) -> "FormatDatabase":
-        return ROS2FormatDatabase(messages, services, actions)
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -10,10 +10,8 @@ from roswire.common import (
     MsgFormat,
     SrvFormat,
     ActionFormat,
-    PackageDatabase,
-    FormatDatabase,
 )
-from roswire.ros1 import ROS1PackageDatabase
+from roswire.ros1 import ROS1PackageDatabase, ROS1FormatDatabase
 
 import dockerblade
 
@@ -414,7 +412,7 @@ def test_msg_from_file(filesystem):
 def test_build_format_database(sut):
     paths = ["/opt/ros/melodic/share/tf2_msgs", "/opt/ros/melodic/share/tf"]
     db_package = ROS1PackageDatabase.build(sut, paths)
-    db_format = FormatDatabase.build(db_package)
+    db_format = ROS1FormatDatabase.build(db_package)
     name_messages: Set[str] = set(db_format.messages)
     name_services: Set[str] = set(db_format.services)
     name_actions: Set[str] = set(db_format.actions)
@@ -446,7 +444,7 @@ def test_msg_toposort(sut):
     ]
 
     db_package = ROS1PackageDatabase.build(sut, paths)
-    db_format = FormatDatabase.build(db_package)
+    db_format = ROS1FormatDatabase.build(db_package)
 
     msgs = db_format.messages.values()
     msgs = MsgFormat.toposort(msgs)

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -412,7 +412,7 @@ def test_msg_from_file(filesystem):
 def test_build_format_database(sut):
     paths = ["/opt/ros/melodic/share/tf2_msgs", "/opt/ros/melodic/share/tf"]
     db_package = ROS1PackageDatabase.build(sut, paths)
-    db_format = ROS1FormatDatabase.build(db_package)
+    db_format = ROS1FormatDatabase.from_packages(db_package)
     name_messages: Set[str] = set(db_format.messages)
     name_services: Set[str] = set(db_format.services)
     name_actions: Set[str] = set(db_format.actions)
@@ -444,7 +444,7 @@ def test_msg_toposort(sut):
     ]
 
     db_package = ROS1PackageDatabase.build(sut, paths)
-    db_format = ROS1FormatDatabase.build(db_package)
+    db_format = ROS1FormatDatabase.from_packages(db_package)
 
     msgs = db_format.messages.values()
     msgs = MsgFormat.toposort(msgs)

--- a/test/test_type_database.py
+++ b/test/test_type_database.py
@@ -22,7 +22,7 @@ def test_build(sut):
     ]
     db_package = ROS1PackageDatabase.build(sut, paths)
 
-    db_format = ROS1FormatDatabase.build(db_package)
+    db_format = ROS1FormatDatabase.from_packages(db_package)
     db_type = TypeDatabase.build(db_format)
     assert set(db_type) == {
         "geometry_msgs/Point",

--- a/test/test_type_database.py
+++ b/test/test_type_database.py
@@ -3,14 +3,12 @@ import pytest
 
 import roswire
 from roswire.common import (
-    PackageDatabase,
-    FormatDatabase,
     TypeDatabase,
     MsgFormat,
     Time,
 )
 
-from roswire.ros1 import ROS1PackageDatabase
+from roswire.ros1 import ROS1FormatDatabase, ROS1PackageDatabase
 
 
 @pytest.mark.parametrize("sut", ["fetch"], indirect=True)
@@ -24,7 +22,7 @@ def test_build(sut):
     ]
     db_package = ROS1PackageDatabase.build(sut, paths)
 
-    db_format = FormatDatabase.build(db_package)
+    db_format = ROS1FormatDatabase.build(db_package)
     db_type = TypeDatabase.build(db_format)
     assert set(db_type) == {
         "geometry_msgs/Point",
@@ -125,7 +123,7 @@ time stamp
 string frame_id
     """
     fmt = MsgFormat.from_string("PkgName", "MessageName", s)
-    db_fmt = FormatDatabase({fmt}, {}, {})
+    db_fmt = ROS1FormatDatabase({fmt}, {}, {})
     db_type = TypeDatabase.build(db_fmt)
 
     t = db_type["PkgName/MessageName"]


### PR DESCRIPTION
FormatDatabase depends on MsgFormat (and classes that depend on MsgFormat). To prepare for processing ROS2 message formats, this PR splits FormatDatabase first.

Note that ROS1FormatDatabase and ROS2FormatDatabase are mostly identical, but will change when ActionFormat and MsgFormat are refactored into different ROS versions.