### PR TITLE
Separate ActionFormat into ROS1 and ROS2 versions

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,4 @@
+cryptography==3.2.1
 flake8==3.7.9
 flake8-bugbear==20.1.4
 flake8-import-order==0.18.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-cryptography==3.2.1
+cryptography==3.3.2
 flake8==3.7.9
 flake8-bugbear==20.1.4
 flake8-import-order==0.18.1

--- a/src/roswire/common/action.py
+++ b/src/roswire/common/action.py
@@ -46,7 +46,7 @@ class ActionFormat(ABC, Generic[MF]):
 
     @classmethod
     def from_file(
-            cls, package: str, filename: str, files: dockerblade.FileSystem
+        cls, package: str, filename: str, files: dockerblade.FileSystem
     ) -> "ActionFormat":
         """Constructs an action format from a .action file for a given package.
 
@@ -87,7 +87,7 @@ class ActionFormat(ABC, Generic[MF]):
     @classmethod
     @abstractmethod
     def from_dict(
-            cls, d: Dict[str, Any], *, package: Optional[str] = None
+        cls, d: Dict[str, Any], *, package: Optional[str] = None
     ) -> "ActionFormat":
         ...
 

--- a/src/roswire/common/action.py
+++ b/src/roswire/common/action.py
@@ -5,6 +5,7 @@ import os
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, Optional, TypeVar
 
+import attr
 import dockerblade
 
 from ..common.msg import MsgFormat
@@ -12,6 +13,7 @@ from ..common.msg import MsgFormat
 MF = TypeVar("MF", bound=MsgFormat)
 
 
+@attr.s(frozen=True)
 class ActionFormat(ABC, Generic[MF]):
     """Provides an immutable definition of a
     `ROS Action <https://www.christimperley.co.uk/roswire/>`_.
@@ -35,12 +37,12 @@ class ActionFormat(ABC, Generic[MF]):
         it has one.
     """
 
-    package: str
-    name: str
-    definition: str
-    goal: MF
-    feedback: Optional[MF]
-    result: Optional[MF]
+    package: str = attr.ib()
+    name: str = attr.ib()
+    definition: str = attr.ib()
+    goal: MF = attr.ib()
+    feedback: Optional[MF] = attr.ib()
+    result: Optional[MF] = attr.ib()
 
     @classmethod
     def from_file(

--- a/src/roswire/ros1/__init__.py
+++ b/src/roswire/ros1/__init__.py
@@ -2,6 +2,7 @@
 from .action import ROS1ActionFormat
 from .format import ROS1FormatDatabase
 from .launch import ROS1LaunchManager
+from .msg import ROS1MsgFormat
 from .node import ROS1Node
 from .node_manager import ROS1NodeManager
 from .package import ROS1Package, ROS1PackageDatabase

--- a/src/roswire/ros1/__init__.py
+++ b/src/roswire/ros1/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from .action import ROS1ActionFormat
 from .format import ROS1FormatDatabase
 from .launch import ROS1LaunchManager
 from .node import ROS1Node

--- a/src/roswire/ros1/action.py
+++ b/src/roswire/ros1/action.py
@@ -4,43 +4,13 @@ __all__ = ("ROS1ActionFormat",)
 import os
 from typing import Any, Dict, List, Optional
 
-import attr
 import dockerblade
 
 from .. import exceptions
 from ..common import ActionFormat, MsgFormat
 
 
-@attr.s(frozen=True, auto_attribs=True, slots=True)
 class ROS1ActionFormat(ActionFormat[MsgFormat]):
-    """Provides an immutable definition of a
-    `ROS Action <https://www.christimperley.co.uk/roswire/>`_.
-
-    Attributes
-    ----------
-    package: str
-        The name of the package to which this action belongs.
-    name: str
-        The name of this action.
-    definition: str
-        The plaintext definition of this action (e.g., the contents of a
-        .action file).
-    goal: MsgFormat
-        The definition of the goal message for this action.
-    feedback: Optional[MsgFormat]
-        The definition of the optional feedback message for this action, if
-        it has one.
-    result: Optional[MsgFormat]
-        The definition of the optional result message for this action, if
-        it has one.
-    """
-
-    package: str
-    name: str
-    definition: str
-    goal: MsgFormat
-    feedback: Optional[MsgFormat]
-    result: Optional[MsgFormat]
 
     @classmethod
     def from_file(
@@ -128,15 +98,17 @@ class ROS1ActionFormat(ActionFormat[MsgFormat]):
 
         return ROS1ActionFormat(package, name, definition, goal, feed, res)
 
-    def to_dict(self) -> Dict[str, Any]:
-        d = {
-            "package": self.package,
-            "name": self.name,
-            "definition": self.definition,
-            "goal": self.goal.to_dict(),
-        }
-        if self.feedback:
-            d["feedback"] = self.feedback.to_dict()
-        if self.result:
-            d["result"] = self.result.to_dict()
-        return d
+    def __init__(self,
+                 package: str,
+                 name: str,
+                 definition: str,
+                 goal: MsgFormat,
+                 feedback: Optional[MsgFormat],
+                 result: Optional[MsgFormat]
+                 ):
+        self.package = package
+        self.name = name
+        self.definition = definition
+        self.goal = goal
+        self.feeback = feedback
+        self.result = result

--- a/src/roswire/ros1/action.py
+++ b/src/roswire/ros1/action.py
@@ -23,9 +23,9 @@ class ROS1ActionFormat(ActionFormat[MsgFormat]):
     def from_string(
         cls, package: str, name: str, s: str
     ) -> "ROS1ActionFormat":
-        goal: ROS1MsgFormat
-        feed: Optional[ROS1MsgFormat]
-        res: Optional[ROS1MsgFormat]
+        goal: MsgFormat
+        feed: Optional[MsgFormat]
+        res: Optional[MsgFormat]
 
         name_goal = f"{name}Goal"
         name_feed = f"{name}Feedback"
@@ -40,7 +40,7 @@ class ROS1ActionFormat(ActionFormat[MsgFormat]):
 
         goal = MsgFormat.from_string(package, name_goal, s_goal)
         feed = MsgFormat.from_string(package, name_feed, s_feed)
-        res = ROS1MsgFormat.from_string(package, name_res, s_res)
+        res = MsgFormat.from_string(package, name_res, s_res)
         return ROS1ActionFormat(package, name, s, goal, feed, res)
 
     @classmethod
@@ -53,18 +53,18 @@ class ROS1ActionFormat(ActionFormat[MsgFormat]):
             assert d["package"] is not None
             package = d["package"]
 
-        res: Optional[ROS1MsgFormat] = None
-        feed: Optional[ROS1MsgFormat] = None
-        goal: MsgFormat = ROS1MsgFormat.from_dict(
+        res: Optional[MsgFormat] = None
+        feed: Optional[MsgFormat] = None
+        goal: MsgFormat = MsgFormat.from_dict(
             d["goal"], package=package, name=f"{name}Goal"
         )
 
         if "result" in d:
-            res = ROS1MsgFormat.from_dict(
+            res = MsgFormat.from_dict(
                 d["result"], package=package, name=f"{name}Result"
             )
         if "feedback" in d:
-            feed = ROS1MsgFormat.from_dict(
+            feed = MsgFormat.from_dict(
                 d["feedback"], package=package, name=f"{name}Feedback"
             )
 

--- a/src/roswire/ros1/action.py
+++ b/src/roswire/ros1/action.py
@@ -5,12 +5,11 @@ from typing import Any, Dict, List, Optional
 
 import dockerblade
 
-from . import ROS1MsgFormat
 from .. import exceptions
-from ..common import ActionFormat
+from ..common import ActionFormat, MsgFormat
 
 
-class ROS1ActionFormat(ActionFormat[ROS1MsgFormat]):
+class ROS1ActionFormat(ActionFormat[MsgFormat]):
 
     @classmethod
     def from_file(
@@ -39,8 +38,8 @@ class ROS1ActionFormat(ActionFormat[ROS1MsgFormat]):
             m = "failed to parse action description: expected three sections."
             raise exceptions.ParsingError(m)
 
-        goal = ROS1MsgFormat.from_string(package, name_goal, s_goal)
-        feed = ROS1MsgFormat.from_string(package, name_feed, s_feed)
+        goal = MsgFormat.from_string(package, name_goal, s_goal)
+        feed = MsgFormat.from_string(package, name_feed, s_feed)
         res = ROS1MsgFormat.from_string(package, name_res, s_res)
         return ROS1ActionFormat(package, name, s, goal, feed, res)
 
@@ -56,7 +55,7 @@ class ROS1ActionFormat(ActionFormat[ROS1MsgFormat]):
 
         res: Optional[ROS1MsgFormat] = None
         feed: Optional[ROS1MsgFormat] = None
-        goal: ROS1MsgFormat = ROS1MsgFormat.from_dict(
+        goal: MsgFormat = ROS1MsgFormat.from_dict(
             d["goal"], package=package, name=f"{name}Goal"
         )
 

--- a/src/roswire/ros1/action.py
+++ b/src/roswire/ros1/action.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 __all__ = ("ROS1ActionFormat",)
 
-import os
 from typing import Any, Dict, List, Optional
 
 import dockerblade
@@ -16,41 +15,14 @@ class ROS1ActionFormat(ActionFormat[MsgFormat]):
     def from_file(
         cls, package: str, filename: str, files: dockerblade.FileSystem
     ) -> "ROS1ActionFormat":
-        """Constructs an action format from a .action file for a given package.
-
-        Parameters
-        ----------
-        package: str
-            The name of the package that provides the file.
-        filename: str
-            The path to the .msg file.
-        files: dockerblade.FileSystem
-            An interface to the filesystem that hosts the .action file.
-
-        Raises
-        ------
-        FileNotFoundError
-            If the given file cannot be found.
-        """
-        assert filename.endswith(
-            ".action"
-        ), "action format files must end in .action"
-        name: str = os.path.basename(filename[:-7])
-        contents: str = files.read(filename)
-        return ROS1ActionFormat.from_string(package, name, contents)
+        fmt = super().from_file(package, filename, files)
+        assert isinstance(fmt, ROS1ActionFormat)
+        return fmt
 
     @classmethod
     def from_string(
         cls, package: str, name: str, s: str
     ) -> "ROS1ActionFormat":
-        """Constructs an action format from its definition (i.e., the contents
-        of a .action file).
-
-        Raises
-        ------
-        ParsingError
-            If the description cannot be parsed.
-        """
         goal: MsgFormat
         feed: Optional[MsgFormat]
         res: Optional[MsgFormat]
@@ -97,18 +69,3 @@ class ROS1ActionFormat(ActionFormat[MsgFormat]):
             )
 
         return ROS1ActionFormat(package, name, definition, goal, feed, res)
-
-    def __init__(self,
-                 package: str,
-                 name: str,
-                 definition: str,
-                 goal: MsgFormat,
-                 feedback: Optional[MsgFormat],
-                 result: Optional[MsgFormat]
-                 ):
-        self.package = package
-        self.name = name
-        self.definition = definition
-        self.goal = goal
-        self.feeback = feedback
-        self.result = result

--- a/src/roswire/ros1/action.py
+++ b/src/roswire/ros1/action.py
@@ -5,11 +5,12 @@ from typing import Any, Dict, List, Optional
 
 import dockerblade
 
+from . import ROS1MsgFormat
 from .. import exceptions
-from ..common import ActionFormat, MsgFormat
+from ..common import ActionFormat
 
 
-class ROS1ActionFormat(ActionFormat[MsgFormat]):
+class ROS1ActionFormat(ActionFormat[ROS1MsgFormat]):
 
     @classmethod
     def from_file(
@@ -23,9 +24,9 @@ class ROS1ActionFormat(ActionFormat[MsgFormat]):
     def from_string(
         cls, package: str, name: str, s: str
     ) -> "ROS1ActionFormat":
-        goal: MsgFormat
-        feed: Optional[MsgFormat]
-        res: Optional[MsgFormat]
+        goal: ROS1MsgFormat
+        feed: Optional[ROS1MsgFormat]
+        res: Optional[ROS1MsgFormat]
 
         name_goal = f"{name}Goal"
         name_feed = f"{name}Feedback"
@@ -38,9 +39,9 @@ class ROS1ActionFormat(ActionFormat[MsgFormat]):
             m = "failed to parse action description: expected three sections."
             raise exceptions.ParsingError(m)
 
-        goal = MsgFormat.from_string(package, name_goal, s_goal)
-        feed = MsgFormat.from_string(package, name_feed, s_feed)
-        res = MsgFormat.from_string(package, name_res, s_res)
+        goal = ROS1MsgFormat.from_string(package, name_goal, s_goal)
+        feed = ROS1MsgFormat.from_string(package, name_feed, s_feed)
+        res = ROS1MsgFormat.from_string(package, name_res, s_res)
         return ROS1ActionFormat(package, name, s, goal, feed, res)
 
     @classmethod
@@ -53,18 +54,18 @@ class ROS1ActionFormat(ActionFormat[MsgFormat]):
             assert d["package"] is not None
             package = d["package"]
 
-        res: Optional[MsgFormat] = None
-        feed: Optional[MsgFormat] = None
-        goal: MsgFormat = MsgFormat.from_dict(
+        res: Optional[ROS1MsgFormat] = None
+        feed: Optional[ROS1MsgFormat] = None
+        goal: ROS1MsgFormat = ROS1MsgFormat.from_dict(
             d["goal"], package=package, name=f"{name}Goal"
         )
 
         if "result" in d:
-            res = MsgFormat.from_dict(
+            res = ROS1MsgFormat.from_dict(
                 d["result"], package=package, name=f"{name}Result"
             )
         if "feedback" in d:
-            feed = MsgFormat.from_dict(
+            feed = ROS1MsgFormat.from_dict(
                 d["feedback"], package=package, name=f"{name}Feedback"
             )
 

--- a/src/roswire/ros1/action.py
+++ b/src/roswire/ros1/action.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+__all__ = ("ROS1ActionFormat",)
+
+import os
+from typing import Any, Dict, List, Optional
+
+import attr
+import dockerblade
+
+from .. import exceptions
+from ..common import ActionFormat, MsgFormat
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class ROS1ActionFormat(ActionFormat[MsgFormat]):
+    """Provides an immutable definition of a
+    `ROS Action <https://www.christimperley.co.uk/roswire/>`_.
+
+    Attributes
+    ----------
+    package: str
+        The name of the package to which this action belongs.
+    name: str
+        The name of this action.
+    definition: str
+        The plaintext definition of this action (e.g., the contents of a
+        .action file).
+    goal: MsgFormat
+        The definition of the goal message for this action.
+    feedback: Optional[MsgFormat]
+        The definition of the optional feedback message for this action, if
+        it has one.
+    result: Optional[MsgFormat]
+        The definition of the optional result message for this action, if
+        it has one.
+    """
+
+    package: str
+    name: str
+    definition: str
+    goal: MsgFormat
+    feedback: Optional[MsgFormat]
+    result: Optional[MsgFormat]
+
+    @classmethod
+    def from_file(
+        cls, package: str, filename: str, files: dockerblade.FileSystem
+    ) -> "ROS1ActionFormat":
+        """Constructs an action format from a .action file for a given package.
+
+        Parameters
+        ----------
+        package: str
+            The name of the package that provides the file.
+        filename: str
+            The path to the .msg file.
+        files: dockerblade.FileSystem
+            An interface to the filesystem that hosts the .action file.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the given file cannot be found.
+        """
+        assert filename.endswith(
+            ".action"
+        ), "action format files must end in .action"
+        name: str = os.path.basename(filename[:-7])
+        contents: str = files.read(filename)
+        return ROS1ActionFormat.from_string(package, name, contents)
+
+    @classmethod
+    def from_string(
+        cls, package: str, name: str, s: str
+    ) -> "ROS1ActionFormat":
+        """Constructs an action format from its definition (i.e., the contents
+        of a .action file).
+
+        Raises
+        ------
+        ParsingError
+            If the description cannot be parsed.
+        """
+        goal: MsgFormat
+        feed: Optional[MsgFormat]
+        res: Optional[MsgFormat]
+
+        name_goal = f"{name}Goal"
+        name_feed = f"{name}Feedback"
+        name_res = f"{name}Result"
+
+        sections: List[str] = [ss.strip() for ss in s.split("---")]
+        try:
+            s_goal, s_res, s_feed = sections
+        except ValueError:
+            m = "failed to parse action description: expected three sections."
+            raise exceptions.ParsingError(m)
+
+        goal = MsgFormat.from_string(package, name_goal, s_goal)
+        feed = MsgFormat.from_string(package, name_feed, s_feed)
+        res = MsgFormat.from_string(package, name_res, s_res)
+        return ROS1ActionFormat(package, name, s, goal, feed, res)
+
+    @classmethod
+    def from_dict(
+        cls, d: Dict[str, Any], *, package: Optional[str] = None
+    ) -> "ROS1ActionFormat":
+        name: str = d["name"]
+        definition: str = d["definition"]
+        if package is None:
+            assert d["package"] is not None
+            package = d["package"]
+
+        res: Optional[MsgFormat] = None
+        feed: Optional[MsgFormat] = None
+        goal: MsgFormat = MsgFormat.from_dict(
+            d["goal"], package=package, name=f"{name}Goal"
+        )
+
+        if "result" in d:
+            res = MsgFormat.from_dict(
+                d["result"], package=package, name=f"{name}Result"
+            )
+        if "feedback" in d:
+            feed = MsgFormat.from_dict(
+                d["feedback"], package=package, name=f"{name}Feedback"
+            )
+
+        return ROS1ActionFormat(package, name, definition, goal, feed, res)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {
+            "package": self.package,
+            "name": self.name,
+            "definition": self.definition,
+            "goal": self.goal.to_dict(),
+        }
+        if self.feedback:
+            d["feedback"] = self.feedback.to_dict()
+        if self.result:
+            d["result"] = self.result.to_dict()
+        return d

--- a/src/roswire/ros1/format.py
+++ b/src/roswire/ros1/format.py
@@ -1,22 +1,32 @@
 # -*- coding: utf-8 -*-
 __all__ = ("ROS1FormatDatabase",)
 
-from typing import Any, Dict
+from typing import Any, Dict, Set
 
+from . import ROS1ActionFormat
 from ..common import (
-    ActionFormat,
     FormatDatabase,
     MsgFormat,
     SrvFormat,
 )
 
 
-class ROS1FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ActionFormat]):
+class ROS1FormatDatabase(FormatDatabase[MsgFormat,
+                                        SrvFormat,
+                                        ROS1ActionFormat]):
+
+    @classmethod
+    def build(cls,
+              messages: Set[MsgFormat],
+              services: Set[SrvFormat],
+              actions: Set[ROS1ActionFormat]
+              ) -> "FormatDatabase":
+        return ROS1FormatDatabase(messages, services, actions)
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
         """Loads a format database from a JSON document."""
         msg = {MsgFormat.from_dict(dd) for dd in d["messages"]}
         srv = {SrvFormat.from_dict(dd) for dd in d["services"]}
-        action = {ActionFormat.from_dict(dd) for dd in d["actions"]}
-        return cls(msg, srv, action)
+        action = {ROS1ActionFormat.from_dict(dd) for dd in d["actions"]}
+        return cls.build(msg, srv, action)

--- a/src/roswire/ros1/format.py
+++ b/src/roswire/ros1/format.py
@@ -16,17 +16,9 @@ class ROS1FormatDatabase(FormatDatabase[MsgFormat,
                                         ROS1ActionFormat]):
 
     @classmethod
-    def build(cls,
-              messages: Set[MsgFormat],
-              services: Set[SrvFormat],
-              actions: Set[ROS1ActionFormat]
-              ) -> "FormatDatabase":
-        return ROS1FormatDatabase(messages, services, actions)
-
-    @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
         """Loads a format database from a JSON document."""
         msg = {MsgFormat.from_dict(dd) for dd in d["messages"]}
         srv = {SrvFormat.from_dict(dd) for dd in d["services"]}
         action = {ROS1ActionFormat.from_dict(dd) for dd in d["actions"]}
-        return cls.build(msg, srv, action)
+        return cls(msg, srv, action)

--- a/src/roswire/ros1/format.py
+++ b/src/roswire/ros1/format.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 __all__ = ("ROS1FormatDatabase",)
 
-from typing import Any, Dict, Set
+from typing import Any, Dict
 
 from . import ROS1ActionFormat
 from ..common import (

--- a/src/roswire/ros1/msg.py
+++ b/src/roswire/ros1/msg.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+__all__ = "ROS1MsgFormat"
+
+from typing import Any, Dict, Optional
+
+import attr
+import dockerblade
+
+from ..common import Field, MsgFormat
+
+
+@attr.s(frozen=True)
+class ROS1MsgFormat(MsgFormat[Field]):
+
+    @classmethod
+    def _field_from_string(cls, package: str, line: str) -> Optional[Field]:
+        return Field.from_string(package, line)
+
+    @classmethod
+    def _field_from_dict(cls, dict: Dict[str, Any]) -> Field:
+        return Field.from_dict(dict)
+
+    @classmethod
+    def from_file(
+        cls, package: str, filename: str, files: dockerblade.FileSystem
+    ) -> "ROS1MsgFormat":
+        mf = super().from_file(package, filename, files)
+        assert isinstance(mf, ROS1MsgFormat)
+        return mf
+
+    @classmethod
+    def from_dict(
+            cls,
+            d: Dict[str, Any],
+            *,
+            package: Optional[str] = None,
+            name: Optional[str] = None
+    ) -> "ROS1MsgFormat":
+        mf = super().from_dict(d, package=package, name=name)
+        assert isinstance(mf, ROS1MsgFormat)
+        return mf

--- a/src/roswire/ros1/package.py
+++ b/src/roswire/ros1/package.py
@@ -9,22 +9,23 @@ from typing import Iterable  # noqa: F401 # Needed for tuple_from_iterable
 import attr
 import dockerblade
 from loguru import logger
-from roswire.common import ActionFormat, MsgFormat, SrvFormat
-from roswire.util import tuple_from_iterable
 
-from ..common import Package, PackageDatabase
+from . import ROS1ActionFormat
+from ..common import MsgFormat, Package, PackageDatabase, SrvFormat
+from ..util import tuple_from_iterable
 
 if typing.TYPE_CHECKING:
     from .. import AppInstance
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
-class ROS1Package(Package[MsgFormat, SrvFormat, ActionFormat]):
+class ROS1Package(Package[MsgFormat, SrvFormat, ROS1ActionFormat]):
     name: str
     path: str
     messages: Collection[MsgFormat] = attr.ib(converter=tuple_from_iterable)
     services: Collection[SrvFormat] = attr.ib(converter=tuple_from_iterable)
-    actions: Collection[ActionFormat] = attr.ib(converter=tuple_from_iterable)
+    actions: Collection[ROS1ActionFormat] = \
+        attr.ib(converter=tuple_from_iterable)
 
     @classmethod
     def build(cls, path: str, app_instance: "AppInstance") -> "ROS1Package":
@@ -32,7 +33,7 @@ class ROS1Package(Package[MsgFormat, SrvFormat, ActionFormat]):
         name: str = os.path.basename(path)
         messages: List[MsgFormat] = []
         services: List[SrvFormat] = []
-        actions: List[ActionFormat] = []
+        actions: List[ROS1ActionFormat] = []
         files = app_instance.files
 
         if not files.isdir(path):
@@ -56,7 +57,7 @@ class ROS1Package(Package[MsgFormat, SrvFormat, ActionFormat]):
             ]
         if files.isdir(dir_action):
             actions = [
-                ActionFormat.from_file(name, f, files)
+                ROS1ActionFormat.from_file(name, f, files)
                 for f in files.listdir(dir_action, absolute=True)
                 if f.endswith(".action")
             ]
@@ -74,8 +75,8 @@ class ROS1Package(Package[MsgFormat, SrvFormat, ActionFormat]):
             SrvFormat.from_dict(dd, package=name)
             for dd in d.get("services", [])
         ]
-        actions: List[ActionFormat] = [
-            ActionFormat.from_dict(dd, package=name)
+        actions: List[ROS1ActionFormat] = [
+            ROS1ActionFormat.from_dict(dd, package=name)
             for dd in d.get("actions", [])
         ]
         return ROS1Package(d["name"], d["path"], messages, services, actions)

--- a/src/roswire/ros2/__init__.py
+++ b/src/roswire/ros2/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from .action import ROS2ActionFormat
 from .format import ROS2FormatDatabase
 from .launch import ROS2LaunchManager
 from .node_manager import ROS2NodeManager

--- a/src/roswire/ros2/__init__.py
+++ b/src/roswire/ros2/__init__.py
@@ -2,6 +2,7 @@
 from .action import ROS2ActionFormat
 from .format import ROS2FormatDatabase
 from .launch import ROS2LaunchManager
+from .msg import ROS2MsgFormat
 from .node_manager import ROS2NodeManager
 from .package import ROS2PackageDatabase
 from .ros2 import ROS2

--- a/src/roswire/ros2/action.py
+++ b/src/roswire/ros2/action.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+__all__ = ("ROS2ActionFormat",)
+
+import os
+from typing import Any, Dict, List, Optional
+
+import attr
+import dockerblade
+
+from .. import exceptions
+from ..common import ActionFormat, MsgFormat
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class ROS2ActionFormat(ActionFormat[MsgFormat]):
+    """Provides an immutable definition of a
+    `ROS Action <https://www.christimperley.co.uk/roswire/>`_.
+
+    Attributes
+    ----------
+    package: str
+        The name of the package to which this action belongs.
+    name: str
+        The name of this action.
+    definition: str
+        The plaintext definition of this action (e.g., the contents of a
+        .action file).
+    goal: MsgFormat
+        The definition of the goal message for this action.
+    feedback: Optional[MsgFormat]
+        The definition of the optional feedback message for this action, if
+        it has one.
+    result: Optional[MsgFormat]
+        The definition of the optional result message for this action, if
+        it has one.
+    """
+
+    package: str
+    name: str
+    definition: str
+    goal: MsgFormat
+    feedback: Optional[MsgFormat]
+    result: Optional[MsgFormat]
+
+    @classmethod
+    def from_file(
+        cls, package: str, filename: str, files: dockerblade.FileSystem
+    ) -> "ROS2ActionFormat":
+        """Constructs an action format from a .action file for a given package.
+
+        Parameters
+        ----------
+        package: str
+            The name of the package that provides the file.
+        filename: str
+            The path to the .msg file.
+        files: dockerblade.FileSystem
+            An interface to the filesystem that hosts the .action file.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the given file cannot be found.
+        """
+        assert filename.endswith(
+            ".action"
+        ), "action format files must end in .action"
+        name: str = os.path.basename(filename[:-7])
+        contents: str = files.read(filename)
+        return ROS2ActionFormat.from_string(package, name, contents)
+
+    @classmethod
+    def from_string(
+        cls, package: str, name: str, s: str
+    ) -> "ROS2ActionFormat":
+        """Constructs an action format from its definition (i.e., the contents
+        of a .action file).
+
+        Raises
+        ------
+        ParsingError
+            If the description cannot be parsed.
+        """
+        goal: MsgFormat
+        feed: Optional[MsgFormat]
+        res: Optional[MsgFormat]
+
+        name_goal = f"{name}Goal"
+        name_feed = f"{name}Feedback"
+        name_res = f"{name}Result"
+
+        sections: List[str] = [ss.strip() for ss in s.split("---")]
+        try:
+            s_goal, s_res, s_feed = sections
+        except ValueError:
+            m = "failed to parse action description: expected three sections."
+            raise exceptions.ParsingError(m)
+
+        goal = MsgFormat.from_string(package, name_goal, s_goal)
+        feed = MsgFormat.from_string(package, name_feed, s_feed)
+        res = MsgFormat.from_string(package, name_res, s_res)
+        return ROS2ActionFormat(package, name, s, goal, feed, res)
+
+    @classmethod
+    def from_dict(
+        cls, d: Dict[str, Any], *, package: Optional[str] = None
+    ) -> "ROS2ActionFormat":
+        name: str = d["name"]
+        definition: str = d["definition"]
+        if package is None:
+            assert d["package"] is not None
+            package = d["package"]
+
+        res: Optional[MsgFormat] = None
+        feed: Optional[MsgFormat] = None
+        goal: MsgFormat = MsgFormat.from_dict(
+            d["goal"], package=package, name=f"{name}Goal"
+        )
+
+        if "result" in d:
+            res = MsgFormat.from_dict(
+                d["result"], package=package, name=f"{name}Result"
+            )
+        if "feedback" in d:
+            feed = MsgFormat.from_dict(
+                d["feedback"], package=package, name=f"{name}Feedback"
+            )
+
+        return ROS2ActionFormat(package, name, definition, goal, feed, res)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {
+            "package": self.package,
+            "name": self.name,
+            "definition": self.definition,
+            "goal": self.goal.to_dict(),
+        }
+        if self.feedback:
+            d["feedback"] = self.feedback.to_dict()
+        if self.result:
+            d["result"] = self.result.to_dict()
+        return d

--- a/src/roswire/ros2/action.py
+++ b/src/roswire/ros2/action.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 __all__ = ("ROS2ActionFormat",)
 
-import os
 from typing import Any, Dict, List, Optional
 
 import dockerblade
@@ -16,41 +15,14 @@ class ROS2ActionFormat(ActionFormat[MsgFormat]):
     def from_file(
         cls, package: str, filename: str, files: dockerblade.FileSystem
     ) -> "ROS2ActionFormat":
-        """Constructs an action format from a .action file for a given package.
-
-        Parameters
-        ----------
-        package: str
-            The name of the package that provides the file.
-        filename: str
-            The path to the .msg file.
-        files: dockerblade.FileSystem
-            An interface to the filesystem that hosts the .action file.
-
-        Raises
-        ------
-        FileNotFoundError
-            If the given file cannot be found.
-        """
-        assert filename.endswith(
-            ".action"
-        ), "action format files must end in .action"
-        name: str = os.path.basename(filename[:-7])
-        contents: str = files.read(filename)
-        return ROS2ActionFormat.from_string(package, name, contents)
+        fmt = super().from_file(package, filename, files)
+        assert isinstance(fmt, ROS2ActionFormat)
+        return fmt
 
     @classmethod
     def from_string(
         cls, package: str, name: str, s: str
     ) -> "ROS2ActionFormat":
-        """Constructs an action format from its definition (i.e., the contents
-        of a .action file).
-
-        Raises
-        ------
-        ParsingError
-            If the description cannot be parsed.
-        """
         goal: MsgFormat
         feed: Optional[MsgFormat]
         res: Optional[MsgFormat]
@@ -97,18 +69,3 @@ class ROS2ActionFormat(ActionFormat[MsgFormat]):
             )
 
         return ROS2ActionFormat(package, name, definition, goal, feed, res)
-
-    def __init__(self,
-                 package: str,
-                 name: str,
-                 definition: str,
-                 goal: MsgFormat,
-                 feedback: Optional[MsgFormat],
-                 result: Optional[MsgFormat]
-                 ):
-        self.package = package
-        self.name = name
-        self.definition = definition
-        self.goal = goal
-        self.feeback = feedback
-        self.result = result

--- a/src/roswire/ros2/action.py
+++ b/src/roswire/ros2/action.py
@@ -4,43 +4,13 @@ __all__ = ("ROS2ActionFormat",)
 import os
 from typing import Any, Dict, List, Optional
 
-import attr
 import dockerblade
 
 from .. import exceptions
 from ..common import ActionFormat, MsgFormat
 
 
-@attr.s(frozen=True, auto_attribs=True, slots=True)
 class ROS2ActionFormat(ActionFormat[MsgFormat]):
-    """Provides an immutable definition of a
-    `ROS Action <https://www.christimperley.co.uk/roswire/>`_.
-
-    Attributes
-    ----------
-    package: str
-        The name of the package to which this action belongs.
-    name: str
-        The name of this action.
-    definition: str
-        The plaintext definition of this action (e.g., the contents of a
-        .action file).
-    goal: MsgFormat
-        The definition of the goal message for this action.
-    feedback: Optional[MsgFormat]
-        The definition of the optional feedback message for this action, if
-        it has one.
-    result: Optional[MsgFormat]
-        The definition of the optional result message for this action, if
-        it has one.
-    """
-
-    package: str
-    name: str
-    definition: str
-    goal: MsgFormat
-    feedback: Optional[MsgFormat]
-    result: Optional[MsgFormat]
 
     @classmethod
     def from_file(
@@ -128,15 +98,17 @@ class ROS2ActionFormat(ActionFormat[MsgFormat]):
 
         return ROS2ActionFormat(package, name, definition, goal, feed, res)
 
-    def to_dict(self) -> Dict[str, Any]:
-        d = {
-            "package": self.package,
-            "name": self.name,
-            "definition": self.definition,
-            "goal": self.goal.to_dict(),
-        }
-        if self.feedback:
-            d["feedback"] = self.feedback.to_dict()
-        if self.result:
-            d["result"] = self.result.to_dict()
-        return d
+    def __init__(self,
+                 package: str,
+                 name: str,
+                 definition: str,
+                 goal: MsgFormat,
+                 feedback: Optional[MsgFormat],
+                 result: Optional[MsgFormat]
+                 ):
+        self.package = package
+        self.name = name
+        self.definition = definition
+        self.goal = goal
+        self.feeback = feedback
+        self.result = result

--- a/src/roswire/ros2/format.py
+++ b/src/roswire/ros2/format.py
@@ -11,7 +11,9 @@ from ..common import (
 )
 
 
-class ROS2FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ROS2ActionFormat]):
+class ROS2FormatDatabase(FormatDatabase[MsgFormat,
+                                        SrvFormat,
+                                        ROS2ActionFormat]):
 
     @classmethod
     def build(cls,

--- a/src/roswire/ros2/format.py
+++ b/src/roswire/ros2/format.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 __all__ = ("ROS2FormatDatabase",)
 
-from typing import Any, Dict, Set
+from typing import Any, Dict
 
 from . import ROS2ActionFormat
 from ..common import (

--- a/src/roswire/ros2/format.py
+++ b/src/roswire/ros2/format.py
@@ -1,22 +1,30 @@
 # -*- coding: utf-8 -*-
 __all__ = ("ROS2FormatDatabase",)
 
-from typing import Any, Dict
+from typing import Any, Dict, Set
 
+from . import ROS2ActionFormat
 from ..common import (
-    ActionFormat,
     FormatDatabase,
     MsgFormat,
     SrvFormat,
 )
 
 
-class ROS2FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ActionFormat]):
+class ROS2FormatDatabase(FormatDatabase[MsgFormat, SrvFormat, ROS2ActionFormat]):
+
+    @classmethod
+    def build(cls,
+              messages: Set[MsgFormat],
+              services: Set[SrvFormat],
+              actions: Set[ROS2ActionFormat]
+              ) -> "FormatDatabase":
+        return ROS2FormatDatabase(messages, services, actions)
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
         """Loads a format database from a JSON document."""
         msg = {MsgFormat.from_dict(dd) for dd in d["messages"]}
         srv = {SrvFormat.from_dict(dd) for dd in d["services"]}
-        action = {ActionFormat.from_dict(dd) for dd in d["actions"]}
+        action = {ROS2ActionFormat.from_dict(dd) for dd in d["actions"]}
         return ROS2FormatDatabase(msg, srv, action)

--- a/src/roswire/ros2/format.py
+++ b/src/roswire/ros2/format.py
@@ -1,24 +1,25 @@
 # -*- coding: utf-8 -*-
 __all__ = ("ROS2FormatDatabase",)
 
-from typing import Any, Dict
+from typing import Any, Dict, Set
 
-from . import ROS2ActionFormat
+from . import ROS2ActionFormat, ROS2MsgFormat
 from ..common import (
     FormatDatabase,
-    MsgFormat,
     SrvFormat,
 )
 
 
-class ROS2FormatDatabase(FormatDatabase[MsgFormat,
+class ROS2FormatDatabase(FormatDatabase[ROS2MsgFormat,
                                         SrvFormat,
                                         ROS2ActionFormat]):
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
         """Loads a format database from a JSON document."""
-        msg = {MsgFormat.from_dict(dd) for dd in d["messages"]}
+        msg: Set[ROS2MsgFormat] = {
+            ROS2MsgFormat.from_dict(dd) for dd in d["messages"]
+        }
         srv = {SrvFormat.from_dict(dd) for dd in d["services"]}
         action = {ROS2ActionFormat.from_dict(dd) for dd in d["actions"]}
         return ROS2FormatDatabase(msg, srv, action)

--- a/src/roswire/ros2/format.py
+++ b/src/roswire/ros2/format.py
@@ -16,14 +16,6 @@ class ROS2FormatDatabase(FormatDatabase[MsgFormat,
                                         ROS2ActionFormat]):
 
     @classmethod
-    def build(cls,
-              messages: Set[MsgFormat],
-              services: Set[SrvFormat],
-              actions: Set[ROS2ActionFormat]
-              ) -> "FormatDatabase":
-        return ROS2FormatDatabase(messages, services, actions)
-
-    @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "FormatDatabase":
         """Loads a format database from a JSON document."""
         msg = {MsgFormat.from_dict(dd) for dd in d["messages"]}

--- a/src/roswire/ros2/msg.py
+++ b/src/roswire/ros2/msg.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+__all__ = ("ROS2Field")
+
+import re
+from typing import Any, Dict, Optional
+
+import attr
+import dockerblade
+
+from ..common import Field
+from ..common.msg import MsgFormat, R_COMMENT
+
+
+@attr.s(frozen=True, str=False, slots=True, auto_attribs=True)
+class ROS2Field(Field):
+    R_DEFAULT_VALUE = r"[^#]*"
+    R_FIELD = re.compile(f"^\s*({Field.R_TYPE})(\s+)({Field.R_NAME})"
+                         f"\s+({R_DEFAULT_VALUE})\s*"
+                         f"{R_COMMENT}$")
+
+    default_val: Optional[str]
+
+    @classmethod
+    def from_string(cls, packages: str, line: str) -> Optional["ROS2Field"]:
+        old_field = Field.from_string(packages, line)
+        m_field = cls.R_FIELD.match(line)
+        if old_field and m_field:
+            def_val = m_field.group(4)
+
+            field: ROS2Field = ROS2Field(old_field.typ,
+                                         old_field.name,
+                                         def_val)
+            return field
+        return None
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "ROS2Field":
+        value: Optional[str] = None
+        if 'default' in d:
+            value = d['default']
+        return ROS2Field(d['type'], d['name'], value)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {'type': self.typ, 'name': self.name}
+        if self.default_val:
+            d['default'] = self.default_val
+        return d
+
+    def __str__(self) -> str:
+        s = super().__str__()
+        if self.default_val:
+            s = f"{s} {self.default_val}"
+        return s
+
+
+@attr.s(frozen=True)
+class ROS2MsgFormat(MsgFormat[ROS2Field]):
+
+    @classmethod
+    def _field_from_dict(cls, dict: Dict[str, Any]) -> ROS2Field:
+        return ROS2Field.from_dict(dict)
+
+    @classmethod
+    def _field_from_string(
+        cls, package: str, line: str
+    ) -> Optional[ROS2Field]:
+        return ROS2Field.from_string(package, line)
+
+    @classmethod
+    def from_file(
+        cls, package: str, filename: str, files: dockerblade.FileSystem
+    ) -> "ROS2MsgFormat":
+        mf = super().from_file(package, filename, files)
+        assert isinstance(mf, ROS2MsgFormat)
+        return mf
+
+    @classmethod
+    def from_dict(
+        cls,
+        d: Dict[str, Any],
+        *,
+        package: Optional[str] = None,
+        name: Optional[str] = None
+    ) -> "ROS2MsgFormat":
+        mf = super().from_dict(d, package=package, name=name)
+        assert isinstance(mf, ROS2MsgFormat)
+        return mf

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -9,9 +9,8 @@ from roswire.common import (
     Field,
     MsgFormat,
     SrvFormat,
-    ActionFormat,
 )
-from roswire.ros1 import ROS1PackageDatabase, ROS1FormatDatabase
+from roswire.ros1 import ROS1ActionFormat, ROS1PackageDatabase, ROS1FormatDatabase
 
 import dockerblade
 
@@ -124,7 +123,7 @@ uint32 total_dishes_cleaned
 float32 percent_complete
 """
 
-    fmt = ActionFormat.from_string("PkgName", "MessageName", s)
+    fmt = ROS1ActionFormat.from_string("PkgName", "MessageName", s)
     assert fmt.name == "MessageName"
     assert fmt.package == "PkgName"
 
@@ -153,7 +152,7 @@ float32 percent_complete
 def test_empty_action_from_string():
     """see #332"""
     s = "---\n---\n"
-    fmt = ActionFormat.from_string("PkgName", "MessageName", s)
+    fmt = ROS1ActionFormat.from_string("PkgName", "MessageName", s)
     assert fmt.goal is not None
     assert not fmt.goal.fields
 
@@ -280,7 +279,7 @@ def test_action_format_to_and_from_dict():
             "fields": [{"type": "int64", "name": "sum"}],
         },
     }
-    f = ActionFormat(
+    f = ROS1ActionFormat(
         package=pkg,
         name=name,
         definition=definition_action,
@@ -300,8 +299,8 @@ def test_action_format_to_and_from_dict():
             fields=[Field("int64", "sum")],
         ),
     )
-    assert ActionFormat.from_dict(d) == f
-    assert ActionFormat.from_dict(f.to_dict()) == f
+    assert ROS1ActionFormat.from_dict(d) == f
+    assert ROS1ActionFormat.from_dict(f.to_dict()) == f
 
 
 @pytest.mark.parametrize("filesystem", ["fetch"], indirect=True)
@@ -310,7 +309,7 @@ def test_action_from_file(filesystem):
     pkg = "tf2_msgs"
     pkg_dir = "/opt/ros/melodic/share/tf2_msgs"
     fn = os.path.join(pkg_dir, "action/LookupTransform.action")
-    fmt = ActionFormat.from_file(pkg, fn, filesystem)
+    fmt = ROS1ActionFormat.from_file(pkg, fn, filesystem)
     assert fmt.package == pkg
     assert fmt.name == "LookupTransform"
     assert fmt.fullname == "tf2_msgs/LookupTransform"
@@ -336,12 +335,12 @@ def test_action_from_file(filesystem):
     # attempt to read .msg file
     fn = os.path.join(pkg_dir, "msg/TFMessage.msg")
     with pytest.raises(AssertionError):
-        ActionFormat.from_file(pkg, fn, filesystem)
+        ROS1ActionFormat.from_file(pkg, fn, filesystem)
 
     # attempt to read non-existent file
     fn = os.path.join(pkg_dir, "action/Spooky.action")
     with pytest.raises(dockerblade.exceptions.ContainerFileNotFound):
-        ActionFormat.from_file(pkg, fn, filesystem)
+        ROS1ActionFormat.from_file(pkg, fn, filesystem)
 
 
 @pytest.mark.parametrize("filesystem", ["fetch"], indirect=True)

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -299,7 +299,9 @@ def test_action_format_to_and_from_dict():
             fields=[Field("int64", "sum")],
         ),
     )
-    assert ROS1ActionFormat.from_dict(d) == f
+
+    f1 = ROS1ActionFormat.from_dict(d)
+    assert f1 == f
     assert ROS1ActionFormat.from_dict(f.to_dict()) == f
 
 


### PR DESCRIPTION
For the moment, functionality is duplicated across ROS1 and ROS2 implementation. Related to #420 