### PR TITLE
Service and action parse fix

### DIFF
--- a/src/roswire/common/msg.py
+++ b/src/roswire/common/msg.py
@@ -308,6 +308,19 @@ class MsgFormat(ABC, Generic[FIELD, CONSTANT]):
         """
         ...
 
+    @staticmethod
+    def sections_from_string(text: str) -> t.List[str]:
+        sections: t.List[str] = []
+        section_index = 0
+        for line in (ss.strip() for ss in text.split("\n")):
+            if line.startswith("---"):
+                section_index += 1
+            else:
+                if len(sections) < section_index + 1:
+                    sections.append("")
+                sections[section_index] += f"{line}\n"
+        return sections
+
     @classmethod
     def from_dict(
         cls,

--- a/src/roswire/ros1/action.py
+++ b/src/roswire/ros1/action.py
@@ -33,18 +33,9 @@ class ROS1ActionFormat(ActionFormat[ROS1MsgFormat]):
         name_feed = f"{name}Feedback"
         name_res = f"{name}Result"
 
-        sections = ["", "", ""]
-        section_index = 0
-        for line in [ss.strip() for ss in s.split("\n")]:
-            if line.startswith("---"):
-                if section_index < 2:
-                    section_index += 1
-                else:
-                    raise ParsingError(f"Action parsing should only have three sections: {s}")
-            else:
-                sections[section_index] += f"{line}\n"
-        if section_index > 2:
-            raise ParsingError(f"Action parsing should only have three sections: {s}")
+        sections = ROS1MsgFormat.sections_from_string(s)
+        if len(sections) != 3:
+            raise ParsingError(f"Action parsing should have three sections: {s}")
         try:
             s_goal, s_res, s_feed = sections
         except ValueError:

--- a/src/roswire/ros1/srv.py
+++ b/src/roswire/ros1/srv.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 import dockerblade
 
 from .msg import ROS1MsgFormat
-from ..common import SrvFormat
+from ..common import MsgFormat, SrvFormat
 from ..exceptions import ParsingError
 
 
@@ -27,16 +27,9 @@ class ROS1SrvFormat(SrvFormat[ROS1MsgFormat]):
         name_req = f"{name}Request"
         name_res = f"{name}Response"
 
-        sections = ["", ""]
-        section_index = 0  # process request first
-        for line in [ss.strip() for ss in s.split('\n')]:
-            if line.startswith("---"):
-                if section_index == 0:
-                    section_index = 1
-                else:
-                    raise ParsingError(f"Should only be one --- in {name} svc for {package}")
-            else:
-                sections[section_index] += f"{line}\n"
+        sections = MsgFormat.sections_from_string(s)
+        if len(sections) < 1 or len(sections) > 2:
+            raise ParsingError(f"Should be one or two sectios for {name} svc for {package}")
 
         s_req = sections[0]
         s_res = sections[1]

--- a/src/roswire/ros2/action.py
+++ b/src/roswire/ros2/action.py
@@ -32,18 +32,9 @@ class ROS2ActionFormat(ActionFormat[ROS2MsgFormat]):
         name_feed = f"{name}Feedback"
         name_res = f"{name}Result"
 
-        sections = ["", "", ""]
-        section_index = 0
-        for line in [ss.strip() for ss in s.split("\n")]:
-            if line.startswith("---"):
-                if section_index < 2:
-                    section_index += 1
-                else:
-                    raise exceptions.ParsingError(f"Action parsing should only have three sections: {s}")
-            else:
-                sections[section_index] += f"{line}\n"
-        if section_index > 2:
-            raise exceptions.ParsingError(f"Action parsing should only have three sections: {s}")
+        sections = ROS2MsgFormat.sections_from_string(s)
+        if len(sections) != 3:
+            raise exceptions.ParsingError(f"Action parsing should have three sections: {s}")
         try:
             s_goal, s_res, s_feed = sections
         except ValueError:

--- a/src/roswire/ros2/srv.py
+++ b/src/roswire/ros2/srv.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 import dockerblade
 
 from .msg import ROS2MsgFormat
-from ..common import SrvFormat
+from ..common import MsgFormat, SrvFormat
 from ..exceptions import ParsingError
 
 
@@ -27,16 +27,9 @@ class ROS2SrvFormat(SrvFormat[ROS2MsgFormat]):
         name_req = f"{name}Request"
         name_res = f"{name}Response"
 
-        sections = ["", ""]
-        section_index = 0  # process request first
-        for line in [ss.strip() for ss in s.split('\n')]:
-            if line.startswith("---"):
-                if section_index == 0:
-                    section_index = 1
-                else:
-                    raise ParsingError(f"Should only be one --- in {name} svc for {package}")
-            else:
-                sections[section_index] += f"{line}\n"
+        sections = MsgFormat.sections_from_string(s)
+        if len(sections) < 1 or len(sections) > 2:
+            raise ParsingError(f"Should be one or two sectios for {name} svc for {package}")
 
         s_req = sections[0]
         s_res = sections[1]


### PR DESCRIPTION
Some service/action files can be separated by `----` rather than `---`. Change parsing to account.