### PR TITLE
Convert node to list so that they are processed in order.

### DIFF
--- a/src/roswire/common/launch/config/launch.py
+++ b/src/roswire/common/launch/config/launch.py
@@ -11,6 +11,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Tuple,
 )
 
 import attr


### PR DESCRIPTION
Nodes in a LaunchConfig were sets, which breaks the ordering required for starting nodelets after nodelet managers.